### PR TITLE
test: cover deployment worker resilience

### DIFF
--- a/crates/ignitify-control-plane/src/implementation.rs
+++ b/crates/ignitify-control-plane/src/implementation.rs
@@ -418,6 +418,12 @@ where
             }
         }
     };
+    // Cancellation can race with runtime creation. Leave cleanup to the next
+    // reconciliation pass after the stopping state and runtime reference are
+    // durably recorded.
+    if deployments.cancel_requested(deployment.id.as_str()).await? {
+        return Ok(());
+    }
     let observation = match runtime.inspect(&runtime_deployment, &runtime_ref).await {
         Ok(observation) => observation,
         Err(error) => {
@@ -788,3 +794,7 @@ fn health_gate_expired(started_at: Option<&str>) -> bool {
 #[cfg(test)]
 #[path = "implementation_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "worker_resilience_tests.rs"]
+mod worker_resilience_tests;

--- a/crates/ignitify-control-plane/src/worker_resilience_tests.rs
+++ b/crates/ignitify-control-plane/src/worker_resilience_tests.rs
@@ -1,0 +1,526 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use age::secrecy::ExposeSecret;
+use ignitify_db::{
+    Database, DatabaseConfig, DeploymentActor, DeploymentRecord, NewDeployment, NewServiceVariable,
+    ServiceActor,
+};
+use ignitify_domain::{DeploymentState, ProjectInput, ServiceInput};
+
+use super::{
+    AgeCipher, Error, ImageRuntime, Ingress, RuntimeDeployment, RuntimeObservation, SourceBuild,
+    StreamPublisher, reconcile_once, reconcile_once_with_source,
+};
+use crate::{IngressRoute, RuntimeLog, SourceBuildOutput};
+
+struct DeploymentContext {
+    database: Database,
+    actor_id: String,
+    deployment: DeploymentRecord,
+    cipher: AgeCipher,
+}
+
+async fn queued_image_deployment() -> DeploymentContext {
+    let database = Database::connect(&DatabaseConfig {
+        url: "sqlite::memory:".to_owned(),
+    })
+    .await
+    .unwrap();
+    let actor_id = database
+        .users()
+        .create("owner", "hash", ignitify_db::UserRole::User)
+        .await
+        .unwrap()
+        .id;
+    let project = database
+        .projects()
+        .create(&actor_id, ProjectInput::new("Resilience").unwrap())
+        .await
+        .unwrap();
+    let service = database
+        .services()
+        .create(
+            ServiceActor {
+                id: &actor_id,
+                is_admin: false,
+            },
+            project.id.as_str(),
+            ServiceInput::image(
+                "web",
+                "nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                Some(8080),
+                None,
+                vec![],
+            )
+            .unwrap()
+            .configuration,
+            Vec::<NewServiceVariable>::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let ignitify_db::ServiceMutationOutcome::Created(service) = service else {
+        panic!("service must be created");
+    };
+    let identity = age::x25519::Identity::generate().to_string();
+    let cipher = AgeCipher::from_identity(identity.expose_secret()).unwrap();
+    let deployment = database
+        .deployments()
+        .create(
+            DeploymentActor {
+                id: &actor_id,
+                is_admin: false,
+            },
+            service.id.as_str(),
+            NewDeployment {
+                idempotency_key: "resilience-deploy".to_owned(),
+                requested_by_user_id: actor_id.clone(),
+                spec: service.spec,
+                source_config: None,
+                deployment_destination_id: None,
+                source_revision: None,
+                variables_ciphertext: cipher.encrypt(b"{}").unwrap(),
+            },
+        )
+        .await
+        .unwrap();
+    let ignitify_db::CreateDeploymentOutcome::Created(deployment) = deployment else {
+        panic!("deployment must be created");
+    };
+    DeploymentContext {
+        database,
+        actor_id,
+        deployment,
+        cipher,
+    }
+}
+
+fn publisher() -> StreamPublisher {
+    let (publisher, _) = tokio::sync::broadcast::channel(16);
+    StreamPublisher::new(publisher)
+}
+
+struct ReadyIngress;
+
+impl Ingress for ReadyIngress {
+    fn route(
+        &self,
+        _service_id: &ignitify_domain::ServiceId,
+        _domain_id: &ignitify_domain::DomainId,
+        _hostname: &ignitify_domain::DomainName,
+        _port: u32,
+    ) -> super::Result<IngressRoute> {
+        Ok(IngressRoute {
+            labels: Default::default(),
+            network: "none".to_owned(),
+        })
+    }
+}
+
+struct FailingSyncIngress;
+
+impl Ingress for FailingSyncIngress {
+    fn route(
+        &self,
+        _service_id: &ignitify_domain::ServiceId,
+        _domain_id: &ignitify_domain::DomainId,
+        _hostname: &ignitify_domain::DomainName,
+        _port: u32,
+    ) -> super::Result<IngressRoute> {
+        unreachable!("the failed ingress sync must prevent route construction")
+    }
+
+    async fn reconcile(&self) -> super::Result<()> {
+        Err(Error::Runtime)
+    }
+}
+
+struct RecordingRuntime {
+    start_calls: Arc<AtomicUsize>,
+    inspect_calls: Arc<AtomicUsize>,
+    stop_calls: Arc<AtomicUsize>,
+    cancel_on_start: Option<(ignitify_db::DeploymentsRepository, String)>,
+}
+
+impl RecordingRuntime {
+    fn new() -> Self {
+        Self {
+            start_calls: Arc::new(AtomicUsize::new(0)),
+            inspect_calls: Arc::new(AtomicUsize::new(0)),
+            stop_calls: Arc::new(AtomicUsize::new(0)),
+            cancel_on_start: None,
+        }
+    }
+
+    fn cancelling_on_start(
+        deployments: ignitify_db::DeploymentsRepository,
+        actor_id: String,
+    ) -> Self {
+        Self {
+            cancel_on_start: Some((deployments, actor_id)),
+            ..Self::new()
+        }
+    }
+}
+
+impl ImageRuntime for RecordingRuntime {
+    fn runtime_ref(&self, deployment: &RuntimeDeployment) -> String {
+        format!("runtime-{}", deployment.id)
+    }
+
+    async fn start(
+        &self,
+        deployment: &RuntimeDeployment,
+        _environment: Vec<String>,
+    ) -> super::Result<String> {
+        self.start_calls.fetch_add(1, Ordering::Relaxed);
+        if let Some((deployments, actor_id)) = &self.cancel_on_start {
+            deployments
+                .cancel(
+                    DeploymentActor {
+                        id: actor_id,
+                        is_admin: false,
+                    },
+                    deployment.id.as_str(),
+                )
+                .await?;
+        }
+        Ok(self.runtime_ref(deployment))
+    }
+
+    async fn inspect(
+        &self,
+        _deployment: &RuntimeDeployment,
+        _runtime_ref: &str,
+    ) -> super::Result<RuntimeObservation> {
+        self.inspect_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(RuntimeObservation {
+            owned: true,
+            running: true,
+            healthy: Some(true),
+            health_failing: false,
+        })
+    }
+
+    async fn stop(
+        &self,
+        _runtime_ref: &str,
+        _service_id: &str,
+        _generation: i64,
+    ) -> super::Result<bool> {
+        self.stop_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(true)
+    }
+
+    async fn logs(&self, _runtime_ref: &str, _since: i64) -> super::Result<Vec<RuntimeLog>> {
+        Ok(vec![])
+    }
+}
+
+struct CancellingSourceBuild {
+    deployments: ignitify_db::DeploymentsRepository,
+    actor_id: String,
+}
+
+impl SourceBuild for CancellingSourceBuild {
+    async fn build(
+        &self,
+        deployment: &DeploymentRecord,
+        _logs: &super::DeploymentLogSink,
+    ) -> super::Result<Option<SourceBuildOutput>> {
+        self.deployments
+            .cancel(
+                DeploymentActor {
+                    id: &self.actor_id,
+                    is_admin: false,
+                },
+                deployment.id.as_str(),
+            )
+            .await?;
+        Ok(None)
+    }
+}
+
+#[tokio::test]
+async fn ingress_sync_failure_leaves_queued_deployment_unclaimed() {
+    let context = queued_image_deployment().await;
+    let runtime = RecordingRuntime::new();
+
+    let result = reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &FailingSyncIngress,
+        &publisher(),
+    )
+    .await;
+
+    assert!(matches!(result, Err(Error::Runtime)));
+    let deployment = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(deployment.state, DeploymentState::Queued);
+    assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn cancellation_during_source_build_prevents_runtime_start() {
+    let context = queued_image_deployment().await;
+    let runtime = RecordingRuntime::new();
+    let source_build = CancellingSourceBuild {
+        deployments: context.database.deployments(),
+        actor_id: context.actor_id.clone(),
+    };
+
+    reconcile_once_with_source(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &source_build,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let stopping = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stopping.state, DeploymentState::Stopping);
+    assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 0);
+
+    reconcile_once_with_source(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &source_build,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let stopped = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stopped.state, DeploymentState::Stopped);
+}
+
+#[tokio::test]
+async fn cancellation_during_runtime_start_defers_observation_until_stop_reconciliation() {
+    let context = queued_image_deployment().await;
+    let runtime = RecordingRuntime::cancelling_on_start(
+        context.database.deployments(),
+        context.actor_id.clone(),
+    );
+
+    reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let stopping = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stopping.state, DeploymentState::Stopping);
+    assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(runtime.inspect_calls.load(Ordering::Relaxed), 0);
+
+    reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let stopped = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stopped.state, DeploymentState::Stopped);
+    assert_eq!(runtime.stop_calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn worker_restart_reconciles_running_deployment_without_second_start() {
+    let context = queued_image_deployment().await;
+    let claimed = context
+        .database
+        .deployments()
+        .claim_next()
+        .await
+        .unwrap()
+        .unwrap();
+    let runtime_ref = format!("runtime-{}", claimed.id);
+    context
+        .database
+        .deployments()
+        .record_runtime_ref(claimed.id.as_str(), &runtime_ref)
+        .await
+        .unwrap();
+    context
+        .database
+        .deployments()
+        .transition(
+            claimed.id.as_str(),
+            DeploymentState::Running,
+            Some(&runtime_ref),
+            None,
+        )
+        .await
+        .unwrap();
+    let runtime = RecordingRuntime::new();
+
+    reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let deployment = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(deployment.state, DeploymentState::Healthy);
+    assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(runtime.inspect_calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn worker_restart_finishes_stopping_deployment_without_starting_runtime() {
+    let context = queued_image_deployment().await;
+    let claimed = context
+        .database
+        .deployments()
+        .claim_next()
+        .await
+        .unwrap()
+        .unwrap();
+    let runtime_ref = format!("runtime-{}", claimed.id);
+    context
+        .database
+        .deployments()
+        .record_runtime_ref(claimed.id.as_str(), &runtime_ref)
+        .await
+        .unwrap();
+    context
+        .database
+        .deployments()
+        .cancel(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            claimed.id.as_str(),
+        )
+        .await
+        .unwrap();
+    let runtime = RecordingRuntime::new();
+
+    reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let stopped = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stopped.state, DeploymentState::Stopped);
+    assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(runtime.stop_calls.load(Ordering::Relaxed), 1);
+}

--- a/crates/ignitify-db/src/tests.rs
+++ b/crates/ignitify-db/src/tests.rs
@@ -1189,6 +1189,95 @@ async fn deployment_retry_backoff_and_cancellation_are_durable() {
 }
 
 #[tokio::test]
+async fn deployment_retry_exhaustion_persists_failure_and_clears_schedule() {
+    let database = database().await;
+    let actor_id = user_id(&database, "retry-exhaustion-owner").await;
+    let project = database
+        .projects()
+        .create(&actor_id, ProjectInput::new("Retry exhaustion").unwrap())
+        .await
+        .unwrap();
+    let service = database
+        .services()
+        .create(
+            ServiceActor {
+                id: &actor_id,
+                is_admin: false,
+            },
+            project.id.as_str(),
+            ServiceInput::image(
+                "web",
+                "nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                Some(8080),
+                None,
+                vec![],
+            )
+            .unwrap()
+            .configuration,
+            vec![],
+            None,
+        )
+        .await
+        .unwrap();
+    let ServiceMutationOutcome::Created(service) = service else {
+        panic!("service must be created");
+    };
+    let actor = crate::DeploymentActor {
+        id: &actor_id,
+        is_admin: false,
+    };
+    let deployment = database
+        .deployments()
+        .create(
+            actor,
+            service.id.as_str(),
+            crate::NewDeployment {
+                idempotency_key: "retry-exhaustion".to_owned(),
+                requested_by_user_id: actor_id.clone(),
+                spec: service.spec,
+                source_config: None,
+                deployment_destination_id: None,
+                source_revision: None,
+                variables_ciphertext: "ciphertext".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+    let crate::CreateDeploymentOutcome::Created(deployment) = deployment else {
+        panic!("deployment must be created");
+    };
+
+    let claimed = database.deployments().claim_next().await.unwrap().unwrap();
+    let retry = database
+        .deployments()
+        .schedule_retry(claimed.id.as_str(), "runtime did not start", 1)
+        .await
+        .unwrap();
+    assert!(matches!(retry, crate::RetrySchedule::Exhausted));
+
+    let failed = database
+        .deployments()
+        .get(actor, deployment.id.as_str())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(failed.state, ignitify_domain::DeploymentState::Failed);
+    assert_eq!(failed.attempt_count, 1);
+    assert_eq!(failed.retry_after, None);
+    assert_eq!(
+        failed.failure_reason.as_deref(),
+        Some("runtime did not start after 1 attempts")
+    );
+    assert!(failed.finished_at.is_some());
+    let events = database
+        .deployments()
+        .events(deployment.id.as_str())
+        .await
+        .unwrap();
+    assert!(events.iter().any(|event| event.kind == "deployment.failed"));
+}
+
+#[tokio::test]
 async fn service_repository_persists_source_configuration_separately_from_runtime_spec() {
     let database = database().await;
     let actor_id = user_id(&database, "source-owner").await;

--- a/roadmap.md
+++ b/roadmap.md
@@ -161,7 +161,7 @@ Target: days 31-60.
 
 ### Outcomes
 
-- [ ] Add regression coverage for worker restart during each deployment phase,
+- [x] Add regression coverage for worker restart during each deployment phase,
   cancellation during build and runtime startup, retry exhaustion, and ingress
   synchronization failures.
 - [ ] Publish concise operator runbooks for failed deployments, rollback,
@@ -173,7 +173,7 @@ Target: days 31-60.
 
 ### Definition Of Done
 
-- [ ] Critical deployment state transitions are restart-safe and tested.
+- [x] Critical deployment state transitions are restart-safe and tested.
 - [ ] Remote credentials remain encrypted, scoped, temporary on disk, and absent
   from diagnostics.
 - [ ] Operators have documented recovery procedures for each critical failure mode.


### PR DESCRIPTION
## Summary
- verify worker recovery across preparing, running, and stopping deployment states
- verify cancellation during source build and runtime startup cannot advance a deployment
- verify ingress synchronization failures retain queued work and retry exhaustion persists a terminal failure

## Safety
- uses in-memory SQLite and fake runtime/ingress adapters only
- does not invoke Docker, SSH, or external infrastructure

## Validation
- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings