### PR TITLE
feat: complete phase 4 remote reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2090,6 +2090,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "yaml-rust2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "tokio",
  "uuid",
  "yaml-rust2",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/ignitify-api/src/handlers/notifications.rs
+++ b/crates/ignitify-api/src/handlers/notifications.rs
@@ -32,6 +32,8 @@ const NOTIFICATION_EVENTS: &[&str] = &[
     "deployment.superseded",
     "backup.succeeded",
     "backup.failed",
+    "remote_agent.offline",
+    "remote_server.authentication_failed",
 ];
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -633,11 +635,19 @@ mod tests {
     fn accepts_selected_known_events_once() {
         let events = normalized_events(vec![
             "backup.failed".to_owned(),
+            "remote_agent.offline".to_owned(),
             "deployment.healthy".to_owned(),
             "backup.failed".to_owned(),
         ])
         .unwrap();
-        assert_eq!(events, ["backup.failed", "deployment.healthy"]);
+        assert_eq!(
+            events,
+            [
+                "backup.failed",
+                "deployment.healthy",
+                "remote_agent.offline"
+            ]
+        );
     }
 
     #[test]

--- a/crates/ignitify-api/src/handlers/remote_servers.rs
+++ b/crates/ignitify-api/src/handlers/remote_servers.rs
@@ -335,7 +335,15 @@ pub(crate) async fn check(
         })?
         .map_err(ssh_command_error)?;
         if !output.status.success() {
-            return Err(ssh_failure_error(&output.stderr));
+            let error = ssh_failure_error(&output.stderr);
+            if is_authentication_failure(&output.stderr) {
+                let _ = state
+                    .database
+                    .remote_server_agents()
+                    .record_authentication_failure(&server_id)
+                    .await;
+            }
+            return Err(error);
         }
         Ok(RemoteServerCheckResponse {
             connected: true,
@@ -740,6 +748,12 @@ fn ssh_failure_error(stderr: &[u8]) -> ApiError {
         "SSH connection failed. Verify the host, port, SSH user, key pair, and known_hosts."
     };
     ApiError::RemoteServerCheckFailedWithReason(message)
+}
+
+fn is_authentication_failure(stderr: &[u8]) -> bool {
+    String::from_utf8_lossy(stderr)
+        .to_ascii_lowercase()
+        .contains("permission denied")
 }
 
 fn optional_public_key(value: Option<String>) -> Result<Option<String>, ApiError> {

--- a/crates/ignitify-api/src/handlers/remote_servers/tests.rs
+++ b/crates/ignitify-api/src/handlers/remote_servers/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    normalize_private_key, public_key_material, ssh_failure_error, ssh_keygen_failure_error,
-    validate_private_key,
+    is_authentication_failure, normalize_private_key, public_key_material, ssh_failure_error,
+    ssh_keygen_failure_error, validate_private_key,
 };
 use crate::error::ApiError;
 
@@ -36,6 +36,12 @@ fn maps_ssh_authentication_failure_without_exposing_stderr() {
             "SSH authentication failed. Install the matching public key in ~/.ssh/authorized_keys."
         )
     ));
+}
+
+#[test]
+fn identifies_only_ssh_authentication_failures_for_alerting() {
+    assert!(is_authentication_failure(b"Permission denied (publickey)."));
+    assert!(!is_authentication_failure(b"Host key verification failed."));
 }
 
 #[test]

--- a/crates/ignitify-core/src/main.rs
+++ b/crates/ignitify-core/src/main.rs
@@ -225,6 +225,10 @@ async fn main() -> Result<()> {
         control.worker_cipher(),
         control.worker_publisher(),
     );
+    let _remote_notification_dispatcher = ignitify_notifications::spawn_remote_event_dispatcher(
+        database.clone(),
+        control.worker_cipher(),
+    );
     let image_runtime = DockerRuntime::from_environment().map_err(|_| CoreError::DockerRuntime)?;
     let compose_runtime = ComposeRuntime::from_environment()?;
     let metrics_runtime = image_runtime.clone();

--- a/crates/ignitify-db/migrations/0032_remote_notification_events.sql
+++ b/crates/ignitify-db/migrations/0032_remote_notification_events.sql
@@ -1,0 +1,43 @@
+CREATE TABLE remote_notification_events (
+    id TEXT PRIMARY KEY,
+    server_id TEXT NOT NULL REFERENCES remote_servers(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL CHECK (kind IN ('remote_agent.offline', 'remote_server.authentication_failed')),
+    message TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    dispatched_at TEXT
+);
+
+CREATE INDEX remote_notification_events_pending_idx
+    ON remote_notification_events(dispatched_at, created_at, id);
+
+CREATE TABLE remote_server_authentication_failures (
+    id TEXT PRIMARY KEY,
+    server_id TEXT NOT NULL REFERENCES remote_servers(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX remote_server_authentication_failures_server_created_idx
+    ON remote_server_authentication_failures(server_id, created_at DESC);
+
+CREATE TABLE notification_deliveries_next (
+    id TEXT PRIMARY KEY,
+    channel_id TEXT NOT NULL REFERENCES notification_channels(id) ON DELETE CASCADE,
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('deployment', 'backup', 'remote')),
+    source_id TEXT NOT NULL,
+    event_kind TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed')),
+    created_at TEXT NOT NULL,
+    completed_at TEXT,
+    message TEXT,
+    UNIQUE(channel_id, source_kind, source_id, event_kind)
+);
+
+INSERT INTO notification_deliveries_next
+    (id, channel_id, source_kind, source_id, event_kind, status, created_at, completed_at, message)
+SELECT id, channel_id, source_kind, source_id, event_kind, status, created_at, completed_at, message
+FROM notification_deliveries;
+
+DROP TABLE notification_deliveries;
+ALTER TABLE notification_deliveries_next RENAME TO notification_deliveries;
+
+CREATE INDEX notification_deliveries_created_idx ON notification_deliveries(created_at DESC);

--- a/crates/ignitify-db/src/lib.rs
+++ b/crates/ignitify-db/src/lib.rs
@@ -28,13 +28,13 @@ pub use repositories::{
     ProjectVariablesMutationOutcome, ProjectsRepository, ProviderAuthMode, ProviderKind,
     ProviderMutationOutcome, ProviderRecord, ProviderUpdate, ProvidersRepository,
     RefreshTokensRepository, RemoteAgentOperationsSummary, RemoteBuilderConnection,
-    RemoteBuilderRecord, RemoteBuilderUpdate, RemoteBuildersRepository, RemoteServerAgentHeartbeat,
-    RemoteServerAgentRecord, RemoteServerAgentsRepository, RemoteServerConnection,
-    RemoteServerRecord, RemoteServerUpdate, RemoteServersRepository, RetrySchedule, SequenceCursor,
-    ServerCertificateRecord, ServerSettingsRecord, ServerSettingsRepository, ServerSettingsUpdate,
-    ServiceActor, ServiceMutationOutcome, ServiceVariableRecord, ServicesRepository,
-    UptimeCheckUpdate, UptimeMonitorRecord, UptimeMonitorUpdate, UptimeMonitorsRepository,
-    UsersRepository,
+    RemoteBuilderRecord, RemoteBuilderUpdate, RemoteBuildersRepository,
+    RemoteNotificationEventRecord, RemoteServerAgentHeartbeat, RemoteServerAgentRecord,
+    RemoteServerAgentsRepository, RemoteServerConnection, RemoteServerRecord, RemoteServerUpdate,
+    RemoteServersRepository, RetrySchedule, SequenceCursor, ServerCertificateRecord,
+    ServerSettingsRecord, ServerSettingsRepository, ServerSettingsUpdate, ServiceActor,
+    ServiceMutationOutcome, ServiceVariableRecord, ServicesRepository, UptimeCheckUpdate,
+    UptimeMonitorRecord, UptimeMonitorUpdate, UptimeMonitorsRepository, UsersRepository,
 };
 
 #[cfg(test)]

--- a/crates/ignitify-db/src/repositories/mod.rs
+++ b/crates/ignitify-db/src/repositories/mod.rs
@@ -64,7 +64,8 @@ pub use remote_builders::{
     RemoteBuildersRepository,
 };
 pub use remote_server_agents::{
-    RemoteServerAgentHeartbeat, RemoteServerAgentRecord, RemoteServerAgentsRepository,
+    RemoteNotificationEventRecord, RemoteServerAgentHeartbeat, RemoteServerAgentRecord,
+    RemoteServerAgentsRepository,
 };
 pub use remote_servers::{
     NewRemoteServer, RemoteServerConnection, RemoteServerRecord, RemoteServerUpdate,

--- a/crates/ignitify-db/src/repositories/remote_server_agents.rs
+++ b/crates/ignitify-db/src/repositories/remote_server_agents.rs
@@ -1,8 +1,11 @@
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use sqlx::{FromRow, SqlitePool};
 use uuid::Uuid;
 
 use crate::Result;
+
+const AUTHENTICATION_FAILURE_WINDOW: Duration = Duration::minutes(15);
+const AUTHENTICATION_FAILURE_THRESHOLD: i64 = 3;
 
 #[derive(Debug, Clone)]
 pub struct RemoteServerAgentRecord {
@@ -35,6 +38,16 @@ pub struct RemoteServerAgentHeartbeat {
     pub docker_containers: Option<i64>,
     pub docker_running_containers: Option<i64>,
     pub reported_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RemoteNotificationEventRecord {
+    pub id: String,
+    pub server_id: String,
+    pub server_name: String,
+    pub kind: String,
+    pub message: String,
+    pub created_at: String,
 }
 
 #[derive(Debug, Clone)]
@@ -204,6 +217,81 @@ impl RemoteServerAgentsRepository {
         Ok(())
     }
 
+    pub async fn record_authentication_failure(&self, server_id: &str) -> Result<()> {
+        let now = Utc::now();
+        let cutoff = (now - AUTHENTICATION_FAILURE_WINDOW).to_rfc3339();
+        let now = now.to_rfc3339();
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query("DELETE FROM remote_server_authentication_failures WHERE created_at < ?")
+            .bind(&cutoff)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(
+            "INSERT INTO remote_server_authentication_failures (id, server_id, created_at)
+             VALUES (?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(server_id)
+        .bind(&now)
+        .execute(&mut *transaction)
+        .await?;
+        let failures = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM remote_server_authentication_failures
+             WHERE server_id = ? AND created_at >= ?",
+        )
+        .bind(server_id)
+        .bind(&cutoff)
+        .fetch_one(&mut *transaction)
+        .await?;
+        if failures == AUTHENTICATION_FAILURE_THRESHOLD {
+            insert_notification_event(
+                &mut transaction,
+                server_id,
+                "remote_server.authentication_failed",
+                "SSH authentication failed repeatedly",
+                &now,
+            )
+            .await?;
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub async fn notification_events(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<RemoteNotificationEventRecord>> {
+        let rows = sqlx::query_as::<_, RemoteNotificationEventRow>(
+            "SELECT events.id, events.server_id, servers.name AS server_name, events.kind,
+                    events.message, events.created_at
+             FROM remote_notification_events events
+             JOIN remote_servers servers ON servers.id = events.server_id
+             WHERE events.dispatched_at IS NULL
+             ORDER BY events.created_at, events.id
+             LIMIT ?",
+        )
+        .bind(limit.clamp(1, 100))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(RemoteNotificationEventRow::into_record)
+            .collect())
+    }
+
+    pub async fn finish_notification_event(&self, event_id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE remote_notification_events
+             SET dispatched_at = ?
+             WHERE id = ? AND dispatched_at IS NULL",
+        )
+        .bind(Utc::now().to_rfc3339())
+        .bind(event_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn mark_stale(&self, cutoff: &str) -> Result<()> {
         let mut transaction = self.pool.begin().await?;
         let rows = sqlx::query_as::<_, StaleAgentRow>(
@@ -232,6 +320,14 @@ impl RemoteServerAgentsRepository {
                 &now,
             )
             .await?;
+            insert_notification_event(
+                &mut transaction,
+                &row.server_id,
+                "remote_agent.offline",
+                "agent heartbeat timed out",
+                &now,
+            )
+            .await?;
         }
         transaction.commit().await?;
         Ok(())
@@ -247,6 +343,27 @@ async fn insert_event(
 ) -> Result<()> {
     sqlx::query(
         "INSERT INTO remote_server_agent_events (id, server_id, kind, message, created_at)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(server_id)
+    .bind(kind)
+    .bind(message)
+    .bind(created_at)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+async fn insert_notification_event(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    server_id: &str,
+    kind: &str,
+    message: &str,
+    created_at: &str,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO remote_notification_events (id, server_id, kind, message, created_at)
          VALUES (?, ?, ?, ?, ?)",
     )
     .bind(Uuid::new_v4().to_string())
@@ -303,4 +420,27 @@ impl RemoteServerAgentRow {
 #[derive(Debug, FromRow)]
 struct StaleAgentRow {
     server_id: String,
+}
+
+#[derive(Debug, FromRow)]
+struct RemoteNotificationEventRow {
+    id: String,
+    server_id: String,
+    server_name: String,
+    kind: String,
+    message: String,
+    created_at: String,
+}
+
+impl RemoteNotificationEventRow {
+    fn into_record(self) -> RemoteNotificationEventRecord {
+        RemoteNotificationEventRecord {
+            id: self.id,
+            server_id: self.server_id,
+            server_name: self.server_name,
+            kind: self.kind,
+            message: self.message,
+            created_at: self.created_at,
+        }
+    }
 }

--- a/crates/ignitify-db/src/repositories/remote_servers.rs
+++ b/crates/ignitify-db/src/repositories/remote_servers.rs
@@ -2,7 +2,7 @@ use chrono::Utc;
 use sqlx::{FromRow, SqlitePool};
 use uuid::Uuid;
 
-use crate::{DatabaseError, Result};
+use crate::{DatabaseError, RemoteServerAgentsRepository, Result};
 
 #[derive(Debug, Clone)]
 pub struct RemoteServerRecord {
@@ -238,6 +238,12 @@ impl RemoteServersRepository {
         .fetch_optional(&self.pool)
         .await?;
         Ok(row.map(RemoteServerConnectionRow::into_connection))
+    }
+
+    pub async fn record_authentication_failure(&self, id: &str) -> Result<()> {
+        RemoteServerAgentsRepository::new(self.pool.clone())
+            .record_authentication_failure(id)
+            .await
     }
 
     async fn get(&self, id: &str) -> Result<Option<RemoteServerRecord>> {

--- a/crates/ignitify-db/src/tests.rs
+++ b/crates/ignitify-db/src/tests.rs
@@ -142,6 +142,20 @@ async fn notification_channels_encrypt_connection_configuration_and_deduplicate_
             .await
             .unwrap()
     );
+    assert!(
+        database
+            .notification_channels()
+            .claim_delivery(&channel.id, "remote", "event-1", "remote_agent.offline")
+            .await
+            .unwrap()
+    );
+    assert!(
+        !database
+            .notification_channels()
+            .claim_delivery(&channel.id, "remote", "event-1", "remote_agent.offline")
+            .await
+            .unwrap()
+    );
     database
         .notification_channels()
         .finish_delivery(&channel.id, "deployment", "42", "deployment.healthy", true)
@@ -619,6 +633,43 @@ async fn remote_server_agent_records_heartbeats_and_marks_stale_hosts_offline() 
         offline.last_error.as_deref(),
         Some("agent heartbeat timed out")
     );
+    let events = agents.notification_events(10).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].server_id, server.id);
+    assert_eq!(events[0].kind, "remote_agent.offline");
+
+    agents
+        .record_authentication_failure(&server.id)
+        .await
+        .unwrap();
+    agents
+        .record_authentication_failure(&server.id)
+        .await
+        .unwrap();
+    assert_eq!(agents.notification_events(10).await.unwrap().len(), 1);
+    agents
+        .record_authentication_failure(&server.id)
+        .await
+        .unwrap();
+    let events = agents.notification_events(10).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == "remote_server.authentication_failed")
+    );
+    agents
+        .record_authentication_failure(&server.id)
+        .await
+        .unwrap();
+    assert_eq!(agents.notification_events(10).await.unwrap().len(), 2);
+    agents
+        .finish_notification_event(&events[0].id)
+        .await
+        .unwrap();
+    let pending = agents.notification_events(10).await.unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_ne!(pending[0].id, events[0].id);
 }
 
 #[tokio::test]

--- a/crates/ignitify-notifications/src/lib.rs
+++ b/crates/ignitify-notifications/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{net::IpAddr, str::FromStr, sync::Arc, time::Duration};
 
 use ignitify_control_plane::{AgeCipher, StreamPublisher, StreamRecord};
-use ignitify_db::{Database, NotificationChannelConnection};
+use ignitify_db::{Database, NotificationChannelConnection, RemoteNotificationEventRecord};
 use lettre::{
     AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor, message::Mailbox,
     transport::smtp::authentication::Credentials,
@@ -22,6 +22,7 @@ use tokio::sync::broadcast;
 use url::Url;
 
 const DELIVERY_TIMEOUT: Duration = Duration::from_secs(15);
+const REMOTE_EVENT_POLL_INTERVAL: Duration = Duration::from_secs(15);
 const USER_AGENT: &str = "Ignitify notifications";
 
 #[derive(Debug, Error)]
@@ -76,6 +77,46 @@ pub fn spawn_deployment_dispatcher(
     })
 }
 
+pub fn spawn_remote_event_dispatcher(
+    database: Database,
+    cipher: Arc<AgeCipher>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(REMOTE_EVENT_POLL_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            match database
+                .remote_server_agents()
+                .notification_events(100)
+                .await
+            {
+                Ok(events) => {
+                    for event in events {
+                        match dispatch_remote_event(&database, cipher.as_ref(), &event).await {
+                            Ok(()) => {
+                                if let Err(error) = database
+                                    .remote_server_agents()
+                                    .finish_notification_event(&event.id)
+                                    .await
+                                {
+                                    tracing::warn!(error = %error, event_id = %event.id, "notification dispatcher could not finish a remote event");
+                                }
+                            }
+                            Err(error) => {
+                                tracing::warn!(error = %error, event_id = %event.id, "notification dispatcher could not prepare a remote event");
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "notification dispatcher could not load remote events")
+                }
+            }
+        }
+    })
+}
+
 pub async fn dispatch_backup(
     database: &Database,
     cipher: &AgeCipher,
@@ -105,6 +146,26 @@ pub async fn dispatch_backup(
             occurred_at: None,
             title,
             body,
+        },
+    )
+    .await
+}
+
+async fn dispatch_remote_event(
+    database: &Database,
+    cipher: &AgeCipher,
+    event: &RemoteNotificationEventRecord,
+) -> Result<()> {
+    dispatch(
+        database,
+        cipher,
+        NotificationEvent {
+            source_kind: "remote",
+            source_id: &event.id,
+            event_kind: &event.kind,
+            occurred_at: Some(&event.created_at),
+            title: remote_event_title(&event.kind),
+            body: remote_event_body(&event.server_name, &event.message),
         },
     )
     .await
@@ -407,13 +468,27 @@ fn deployment_body(deployment_id: &str, kind: &str) -> String {
     format!("Ignitify deployment {deployment_id} emitted {kind}.")
 }
 
+fn remote_event_title(kind: &str) -> &'static str {
+    match kind {
+        "remote_agent.offline" => "Remote agent offline",
+        "remote_server.authentication_failed" => "Remote SSH authentication failing",
+        _ => "Remote runtime event",
+    }
+}
+
+fn remote_event_body(server_name: &str, message: &str) -> String {
+    format!("Ignitify remote server {server_name}: {message}.")
+}
+
 fn bounded_message(value: &str) -> String {
     value.chars().take(4_000).collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{bounded_message, deployment_body, deployment_title};
+    use super::{
+        bounded_message, deployment_body, deployment_title, remote_event_body, remote_event_title,
+    };
 
     #[test]
     fn deployment_notification_content_is_bounded_and_non_sensitive() {
@@ -423,5 +498,17 @@ mod tests {
             "Ignitify deployment deploy-123 emitted deployment.failed."
         );
         assert_eq!(bounded_message(&"x".repeat(5_000)).chars().count(), 4_000);
+    }
+
+    #[test]
+    fn remote_notification_content_is_bounded_and_non_sensitive() {
+        assert_eq!(
+            remote_event_title("remote_agent.offline"),
+            "Remote agent offline"
+        );
+        assert_eq!(
+            remote_event_body("Production VM", "agent heartbeat timed out"),
+            "Ignitify remote server Production VM: agent heartbeat timed out."
+        );
     }
 }

--- a/crates/ignitify-runtime-remote/Cargo.toml
+++ b/crates/ignitify-runtime-remote/Cargo.toml
@@ -17,3 +17,4 @@ sha2.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 yaml-rust2.workspace = true
+zeroize.workspace = true

--- a/crates/ignitify-runtime-remote/src/lib.rs
+++ b/crates/ignitify-runtime-remote/src/lib.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::{io::AsyncWriteExt, process::Command, time::timeout};
 use yaml_rust2::YamlLoader;
+use zeroize::Zeroizing;
 
 const SSH_TIMEOUT: Duration = Duration::from_secs(45);
 const PROXY_NETWORK: &str = "ignitify-proxy";
@@ -57,8 +58,8 @@ impl SshRuntime {
             .map_err(|_| ControlError::Runtime)?;
         Ok(RemoteSecrets {
             connection,
-            private_key: private_key.to_vec(),
-            known_hosts: known_hosts.to_vec(),
+            private_key,
+            known_hosts,
         })
     }
 
@@ -532,8 +533,8 @@ impl ImageRuntime for SshRuntime {
 
 struct RemoteSecrets {
     connection: RemoteServerConnection,
-    private_key: Vec<u8>,
-    known_hosts: Vec<u8>,
+    private_key: Zeroizing<Vec<u8>>,
+    known_hosts: Zeroizing<Vec<u8>>,
 }
 
 struct RemoteOutput {
@@ -547,8 +548,8 @@ fn tempfile_directory() -> std::path::PathBuf {
     std::env::temp_dir().join(format!("ignitify-remote-{}", uuid::Uuid::new_v4()))
 }
 
-fn terminated_key(key: &[u8]) -> Vec<u8> {
-    let mut value = key.to_vec();
+fn terminated_key(key: &[u8]) -> Zeroizing<Vec<u8>> {
+    let mut value = Zeroizing::new(key.to_vec());
     if !value.ends_with(b"\n") {
         value.push(b'\n');
     }
@@ -659,7 +660,7 @@ fn parse_logs(stdout: &str, stderr: &str) -> Vec<RuntimeLog> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SshRuntime, parse_observation, parse_runtime_ref, shell_quote};
+    use super::{SshRuntime, parse_observation, parse_runtime_ref, shell_quote, terminated_key};
     use ignitify_control_plane::RuntimeDeployment;
     use ignitify_domain::{DeploymentId, ServiceId, ServiceSpec};
 
@@ -720,6 +721,12 @@ mod tests {
     #[test]
     fn shell_quote_does_not_expand_values() {
         assert_eq!(shell_quote("a'b"), "'a'\\''b'");
+    }
+
+    #[test]
+    fn private_key_termination_uses_a_zeroizing_buffer() {
+        let value = terminated_key(b"private-key");
+        assert_eq!(value.as_slice(), b"private-key\n");
     }
 
     #[test]

--- a/crates/ignitify-runtime-remote/src/lib.rs
+++ b/crates/ignitify-runtime-remote/src/lib.rs
@@ -138,6 +138,12 @@ impl SshRuntime {
                 .await
                 .map_err(|_| ControlError::Runtime)?
                 .map_err(|_| ControlError::Runtime)?;
+            if !output.status.success() && is_authentication_failure(&output.stderr) {
+                let _ = self
+                    .servers
+                    .record_authentication_failure(&secrets.connection.id)
+                    .await;
+            }
             Ok(RemoteOutput {
                 success: output.status.success(),
                 stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
@@ -582,6 +588,12 @@ fn yaml_quote(value: &str) -> String {
         .replace(['\n', '\r'], " ")
 }
 
+fn is_authentication_failure(stderr: &[u8]) -> bool {
+    String::from_utf8_lossy(stderr)
+        .to_ascii_lowercase()
+        .contains("permission denied")
+}
+
 fn parse_runtime_ref(value: &str) -> Option<(&str, &str, i64)> {
     let value = value.strip_prefix("ignitify-remote-")?;
     let (value, generation) = value.rsplit_once("-g")?;
@@ -660,7 +672,10 @@ fn parse_logs(stdout: &str, stderr: &str) -> Vec<RuntimeLog> {
 
 #[cfg(test)]
 mod tests {
-    use super::{SshRuntime, parse_observation, parse_runtime_ref, shell_quote, terminated_key};
+    use super::{
+        SshRuntime, is_authentication_failure, parse_observation, parse_runtime_ref, shell_quote,
+        terminated_key,
+    };
     use ignitify_control_plane::RuntimeDeployment;
     use ignitify_domain::{DeploymentId, ServiceId, ServiceSpec};
 
@@ -727,6 +742,12 @@ mod tests {
     fn private_key_termination_uses_a_zeroizing_buffer() {
         let value = terminated_key(b"private-key");
         assert_eq!(value.as_slice(), b"private-key\n");
+    }
+
+    #[test]
+    fn remote_authentication_failure_detection_is_safe() {
+        assert!(is_authentication_failure(b"Permission denied (publickey)."));
+        assert!(!is_authentication_failure(b"Host key verification failed."));
     }
 
     #[test]

--- a/crates/ignitify-source-git/Cargo.toml
+++ b/crates/ignitify-source-git/Cargo.toml
@@ -18,4 +18,5 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
+uuid.workspace = true
 yaml-rust2.workspace = true

--- a/crates/ignitify-source-git/src/lib.rs
+++ b/crates/ignitify-source-git/src/lib.rs
@@ -14,6 +14,9 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use ignitify_control_plane::{
     AgeCipher, DeploymentLogSink, Error as ControlError, SourceBuild, SourceBuildOutput,
@@ -444,6 +447,7 @@ impl GitSourceBuild {
         let certificate_dir = self.root.join(format!("{deployment_id}.remote-builder"));
         remove_dir_if_exists(&certificate_dir).await?;
         fs::create_dir_all(&certificate_dir).await?;
+        set_sensitive_directory_permissions(&certificate_dir).await?;
         let ca_path = certificate_dir.join("ca.pem");
         let certificate_path = certificate_dir.join("client.pem");
         let key_path = certificate_dir.join("client-key.pem");
@@ -768,6 +772,16 @@ async fn remove_dir_if_exists(path: &Path) -> Result<(), std::io::Error> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+async fn set_sensitive_directory_permissions(path: &Path) -> Result<(), std::io::Error> {
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).await?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
 }
 
 async fn remote_image_reference(image: &str, metadata: &Path) -> Result<String, BuildError> {

--- a/crates/ignitify-source-git/src/tests.rs
+++ b/crates/ignitify-source-git/src/tests.rs
@@ -10,6 +10,27 @@ use ignitify_db::{Database, DatabaseConfig};
 use ignitify_domain::ServiceSpec;
 use std::sync::Arc;
 
+#[cfg(unix)]
+#[tokio::test]
+async fn remote_builder_certificate_directory_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory =
+        std::env::temp_dir().join(format!("ignitify-source-test-{}", uuid::Uuid::new_v4()));
+    tokio::fs::create_dir(&directory).await.unwrap();
+    super::set_sensitive_directory_permissions(&directory)
+        .await
+        .unwrap();
+    let mode = tokio::fs::metadata(&directory)
+        .await
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    let _ = tokio::fs::remove_dir_all(&directory).await;
+    assert_eq!(mode, 0o700);
+}
+
 #[test]
 fn static_build_uses_the_generated_dockerfile_not_the_host_shell() {
     let dockerfile = static_dockerfile(

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -148,9 +148,11 @@ export default {
       deploymentFailed: "Deployment failed",
       deploymentStopping: "Deployment stopping",
       deploymentStopped: "Deployment stopped",
-      deploymentSuperseded: "Deployment superseded",
       backupSucceeded: "Backup completed",
       backupFailed: "Backup failed",
+      remoteAgentOffline: "Remote agent offline",
+      remoteServerAuthenticationFailed: "Remote SSH authentication failing",
+      deploymentSuperseded: "Deployment superseded",
     },
   },
   deploymentLogs: {

--- a/frontend/src/i18n/locales/id.ts
+++ b/frontend/src/i18n/locales/id.ts
@@ -148,9 +148,11 @@ export default {
       deploymentFailed: "Deployment gagal",
       deploymentStopping: "Deployment dihentikan",
       deploymentStopped: "Deployment berhenti",
-      deploymentSuperseded: "Deployment digantikan",
       backupSucceeded: "Backup selesai",
       backupFailed: "Backup gagal",
+      remoteAgentOffline: "Agen remote offline",
+      remoteServerAuthenticationFailed: "Autentikasi SSH remote gagal berulang",
+      deploymentSuperseded: "Deployment digantikan",
     },
   },
   deploymentLogs: {

--- a/frontend/src/lib/api/notifications.ts
+++ b/frontend/src/lib/api/notifications.ts
@@ -13,7 +13,9 @@ export type NotificationEventKind =
   | "deployment.stopped"
   | "deployment.superseded"
   | "backup.succeeded"
-  | "backup.failed";
+  | "backup.failed"
+  | "remote_agent.offline"
+  | "remote_server.authentication_failed";
 
 export interface NotificationChannel {
   id: string;

--- a/frontend/src/views/NotificationsView.vue
+++ b/frontend/src/views/NotificationsView.vue
@@ -79,6 +79,11 @@ const events: { value: NotificationEventKind; labelKey: string }[] = [
   { value: "deployment.superseded", labelKey: "notifications.event.deploymentSuperseded" },
   { value: "backup.succeeded", labelKey: "notifications.event.backupSucceeded" },
   { value: "backup.failed", labelKey: "notifications.event.backupFailed" },
+  { value: "remote_agent.offline", labelKey: "notifications.event.remoteAgentOffline" },
+  {
+    value: "remote_server.authentication_failed",
+    labelKey: "notifications.event.remoteServerAuthenticationFailed",
+  },
 ];
 
 const kindIcons: Record<NotificationChannelKind, Component> = {

--- a/infra/operations/README.md
+++ b/infra/operations/README.md
@@ -53,3 +53,7 @@ material backup or release changes. It defines the 24-hour RPO and 60-minute
 RTO objectives, validates a supported release artifact in an isolated location,
 and records the required recovery evidence without starting a restored control
 plane.
+
+For deployment, rollback, certificate, remote-server, and backup incidents,
+follow the concise [operator failure runbooks](runbooks.md) before making
+runtime changes.

--- a/infra/operations/runbooks.md
+++ b/infra/operations/runbooks.md
@@ -1,0 +1,102 @@
+# Operator Failure Runbooks
+
+These procedures apply to an operator working on the Ignitify host. They are
+deliberately read-only until the recovery action is explicitly named. Do not
+run Docker, Compose, SSH, DNS, or restore commands against production while
+investigating unless that action is part of the selected runbook.
+
+## Common Triage
+
+1. Open the operator health summary at `/api/v1/operations/health-summary` or
+   the Dashboard operations panel.
+2. Record the deployment ID, service, destination, current status, and the
+   request or audit ID before taking action.
+3. Review the deployment events and logs for the same deployment. Treat log
+   text as diagnostic data; do not paste environment values, tokens, keys, or
+   unredacted command output into an incident record.
+4. Check whether the worker is progressing. A queued deployment can be safely
+   retried after the underlying dependency is restored; a running deployment
+   must be inspected before submitting another deployment.
+
+## Failed Deployment
+
+Use the service deployment/activity view to identify whether the failure is in
+source build, runtime start/health, or ingress synchronization.
+
+- Source build failure: verify the provider/repository and immutable source
+  revision, then retry after the provider or builder is healthy.
+- Runtime failure: inspect the bounded container/runtime logs and resource
+  settings. Stop the unhealthy service before changing its configuration.
+- Ingress failure: verify the domain target and certificate state, then retry
+  after ingress is healthy. Do not expose the loopback control-plane port.
+
+Submit a new deployment only after recording the failed deployment. Use cancel
+for an in-progress deployment that must not continue; use stop for the running
+service. The worker owns cleanup and retry state, so do not remove containers
+or Compose projects manually as a first response.
+
+## Rollback
+
+1. Confirm the target deployment is the last known-good generation and capture
+   its image digest or source revision from deployment history.
+2. Submit rollback from the deployment activity view. The API operation is
+   `POST /api/v1/deployments/{deployment_id}/rollback` and requires an
+   idempotency key; repeat requests with the same key are safe.
+3. Watch the resulting deployment events and logs until the service is healthy
+   or the rollback reaches a terminal failure.
+4. If rollback fails, leave the failed record intact, stop the affected service
+   only when it is unsafe to keep running, and continue with the runtime or
+   ingress section below.
+
+## Certificate Or Ingress Failure
+
+1. Check Infrastructure settings and the health summary certificate/domain
+   status.
+2. For Let's Encrypt, verify the ACME contact, control-plane hostname, DNS
+   record, and that the validation endpoint is reachable through Traefik.
+3. For a custom certificate, verify that the selected certificate has both PEM
+   files and that its hostname matches the configured control-plane/domain
+   names. Upload a replacement before deleting the old certificate.
+4. Re-run domain verification, then retry the affected deployment. Keep the
+   control plane loopback-only; never add a direct route to port `5656`.
+
+## Remote Server Connection Failure
+
+1. In Remote Servers, run the connection check and record only its safe
+   diagnostic message and latency.
+2. Verify host, port, user, firewall access, and that the installed public key
+   matches the encrypted private key. If host-key verification fails, obtain a
+   verified current host key out of band and replace `known_hosts`; never
+   disable strict host-key checking.
+3. If an agent is configured, inspect its heartbeat age. Reinstall or rotate
+   the agent installation when authentication repeatedly fails, then verify a
+   fresh heartbeat.
+4. Retry the deployment only after the check succeeds. SSH credentials are
+   decrypted only for the operation, written to mode-`0600` temporary files,
+   and removed when the command or terminal ends; do not collect those files as
+   diagnostics.
+
+## Backup Recovery
+
+Use the [offline restore drill](restore-drill.md) for the complete procedure.
+The short sequence is:
+
+1. Select a complete local backup or an S3 prefix containing `manifest.json`.
+2. Verify the manifest hashes and the matching release archive checksum/SBOM.
+3. Stop Ignitify, set an isolated `IGNITIFY_DATA_DIR` and database URL, and run
+   `ignitify-core restore <directory> --confirm-offline`.
+4. Validate SQLite integrity, secret-file existence and mode `0600`, and the
+   `restore-recovery-*` directory before starting any process.
+5. Re-enter the S3 destination with a separately retained recovery credential;
+   the destination is intentionally stripped from every backup snapshot.
+
+Never restore through the web UI, start a restored instance against production
+infrastructure, or delete the recovery directory before incident evidence is
+retained.
+
+## Incident Evidence
+
+Record the UTC time, release/tag, deployment and service IDs, health-summary
+status, selected action, outcome, and follow-up issue. Redact customer names,
+repository credentials, environment values, private keys, certificate keys,
+signed URLs, and raw provider error bodies.

--- a/infra/operations/runbooks.md
+++ b/infra/operations/runbooks.md
@@ -76,6 +76,24 @@ or Compose projects manually as a first response.
    and removed when the command or terminal ends; do not collect those files as
    diagnostics.
 
+## Remote Credential Rotation
+
+Rotate credentials by updating the corresponding Remote Servers or Remote
+Builders record with material verified out of band. A remote-server update can
+replace its private key, public key, and `known_hosts`; replace the host key
+only after independently verifying the remote host identity. A remote-builder
+update requires a complete CA certificate, client certificate, and client key,
+plus an optional verified TLS server name.
+
+The application encrypts both SSH and mTLS credential material at rest. During
+use, SSH commands have a 10-second connection timeout and a 45-second command
+timeout. Remote-builder commands have a bounded configurable timeout (15
+minutes by default). The build adapter creates a mode-`0700` per-deployment
+certificate directory, writes mTLS files at mode `0600`, removes them after
+builder cleanup, and removes them on setup failure. Deployment logs contain
+operation status rather than credential material. Do not rotate by editing the
+SQLite database or by recovering temporary files.
+
 ## Backup Recovery
 
 Use the [offline restore drill](restore-drill.md) for the complete procedure.

--- a/roadmap.md
+++ b/roadmap.md
@@ -168,7 +168,7 @@ Target: days 31-60.
   certificate failures, remote-server connection failure, and backup recovery.
 - [x] Audit SSH and mTLS credential rotation, temporary file cleanup, known-host
   lifecycle, command timeout behavior, and failure redaction.
-- [ ] Notify operators when remote agents are offline or remote authentication
+- [x] Notify operators when remote agents are offline or remote authentication
   starts failing repeatedly.
 
 ### Definition Of Done

--- a/roadmap.md
+++ b/roadmap.md
@@ -164,9 +164,9 @@ Target: days 31-60.
 - [x] Add regression coverage for worker restart during each deployment phase,
   cancellation during build and runtime startup, retry exhaustion, and ingress
   synchronization failures.
-- [ ] Publish concise operator runbooks for failed deployments, rollback,
+- [x] Publish concise operator runbooks for failed deployments, rollback,
   certificate failures, remote-server connection failure, and backup recovery.
-- [ ] Audit SSH and mTLS credential rotation, temporary file cleanup, known-host
+- [x] Audit SSH and mTLS credential rotation, temporary file cleanup, known-host
   lifecycle, command timeout behavior, and failure redaction.
 - [ ] Notify operators when remote agents are offline or remote authentication
   starts failing repeatedly.
@@ -174,9 +174,9 @@ Target: days 31-60.
 ### Definition Of Done
 
 - [x] Critical deployment state transitions are restart-safe and tested.
-- [ ] Remote credentials remain encrypted, scoped, temporary on disk, and absent
+- [x] Remote credentials remain encrypted, scoped, temporary on disk, and absent
   from diagnostics.
-- [ ] Operators have documented recovery procedures for each critical failure mode.
+- [x] Operators have documented recovery procedures for each critical failure mode.
 
 ## Phase 5: Secure Delivery And Production Governance
 


### PR DESCRIPTION
## Summary\n- add operator failure runbooks and complete Phase 4 checklist\n- zeroize remote SSH credentials and tighten temporary mTLS material permissions\n- persist remote-agent offline and repeated SSH authentication failures as durable notification events\n- dispatch remote alerts through existing encrypted, deduplicated notification channels\n\n## Validation\n- Rust focused tests, fmt, check, workspace tests, and clippy pass\n- frontend check, 90 Vitest tests, build, and 5 Playwright fixture tests pass\n- no runtime Docker/Compose/SSH effects were invoked\n