### PR TITLE
docs: publish VitePress-ready documentation content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Ignitify Documentation Content
+
+This directory is the source content for the public Ignitify documentation.
+The separate Ignitify marketing repository owns the VitePress application,
+navigation, theme, deployment, and generated site output.
+
+## Content contract
+
+- English is the default locale at `docs/`.
+- Indonesian translations mirror the same path under `docs/id/`.
+- Keep page paths, headings, relative links, and relative asset references
+  portable so the marketing site can mount this directory as its VitePress
+  documentation root.
+- Changes to pages here that add, remove, or rename routes require the matching
+  VitePress sidebar and navigation update in the marketing repository.
+- Keep this directory to reviewed Markdown content and safe static assets. Do
+  not add VitePress configuration, dependencies, generated site output, or
+  deployment files here.
+
+Documentation describes implemented behavior. Track planned work in
+[`../roadmap.md`](../roadmap.md), not in user-facing reference pages.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,61 @@
+# Architecture
+
+Ignitify separates HTTP, domain, persistence, and external side effects. This keeps handlers thin, makes validation testable without a Docker runtime, and limits where secrets or host access are available.
+
+## Runtime components
+
+```text
+Browser dashboard
+  -> Vue Router / Pinia / typed API client
+  -> Vite proxy during development
+  -> Axum API
+       -> AuthService + SQLite repositories
+       -> ServiceControl / ControlHandle
+       -> deployment worker
+            -> Docker or Compose runtime
+            -> Git source builder
+            -> Traefik ingress
+```
+
+`ignitify-core` reads configuration, creates runtime secrets when needed, opens SQLite, creates Docker/Compose/Traefik/Git adapters, and starts the worker and Axum router. The default listener is `127.0.0.1:5656`.
+
+## Crates and responsibilities
+
+| Crate                      | Responsibility                                                                           |
+| -------------------------- | ---------------------------------------------------------------------------------------- |
+| `ignitify-core`            | Composition root, listener, runtime secrets, and dependency readiness.                   |
+| `ignitify-api`             | Routes, HTTP DTOs, auth/origin extraction, cookies, SSE streams, and safe error mapping. |
+| `ignitify-auth`            | Argon2 passwords, JWT access tokens, rotating refresh tokens, and sessions.              |
+| `ignitify-db`              | SQLite pool, embedded migrations, persistence models, and authorized repositories.       |
+| `ignitify-domain`          | Identifiers, service specs, deployment/domain status, and input rules.                   |
+| `ignitify-control-plane`   | Environment encryption, deployment submission, worker, lifecycle, and event/log streams. |
+| `ignitify-runtime-docker`  | Inventory, metrics, container actions, and OCI image runtime.                            |
+| `ignitify-runtime-compose` | Compose service validation and lifecycle.                                                |
+| `ignitify-ingress-traefik` | Traefik network and labels for service domains.                                          |
+| `ignitify-source-git`      | Source checkout, commit resolution, and Dockerfile/static/Railpack builders.             |
+| `ignitify-terminal`        | Protected PTY terminals for hosts and containers.                                        |
+
+## Persistent data
+
+SQLite stores users, refresh token hashes, projects and memberships, services, deployments, domains, activity, providers, and source configuration. Migrations live in `ignitify-db/migrations/` and are embedded by the database crate.
+
+Project and service environment values are not stored as plaintext. `ServiceControl` encrypts values with age, using a runtime identity stored separately from the database. When read, secret values remain masked; non-secret values can only be opened by roles allowed to manage the service.
+
+## Authorization
+
+Authentication produces an `AuthenticatedUser` with an `admin` or `user` role. Within a project, membership roles are:
+
+| Role     | Permission                                                |
+| -------- | --------------------------------------------------------- |
+| `owner`  | Change the project and manage services/environment.       |
+| `editor` | Manage services/environment without changing the project. |
+| `viewer` | Read accessible resources.                                |
+| `admin`  | Cross-project access and protected host operations.       |
+
+Repositories receive the actor and evaluate access before returning data. Handlers must not rely on UI filtering to enforce authorization.
+
+## Observability and health
+
+`GET /health` is an unauthenticated basic probe. `GET /api/v1/runtime/status` checks the database, runtime, worker, ingress, and host metrics as `ready` or `unavailable`. Detailed system metrics are available at `GET /api/v1/runtime/metrics`; Docker inventory is available through the runtime endpoints.
+
+Deployment events and logs use SSE. Streams can replay from a stored cursor (`Last-Event-ID` or `after`) and send a snapshot when the client's cursor is older than the event retention window.

--- a/docs/concepts/deployment-lifecycle.md
+++ b/docs/concepts/deployment-lifecycle.md
@@ -1,0 +1,63 @@
+# Deployment lifecycle
+
+## Resource model
+
+A project has a default environment and many services. A service has runtime configuration, variables, optional source configuration, and a desired generation/state. A deployment is an immutable snapshot of the service and environment when the request is accepted.
+
+```text
+Project environment
+       +
+Service variables
+       |
+       v
+encrypted deployment snapshot -> queue -> worker -> runtime + ingress
+```
+
+Project environment values are merged first, then service variables with the same key override them. The deployment snapshot is encrypted before it is stored. Later environment changes do not alter a submitted deployment.
+
+## Service kinds
+
+| Kind      | Configuration                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------- |
+| `image`   | OCI reference pinned to a SHA-256 digest, with an optional internal port and exec-form healthcheck. |
+| `compose` | Compose YAML, exposed service name, and an optional internal port.                                  |
+
+Service names and exposed Compose services must be lower-case DNS labels. Compose YAML is limited to 1 MiB and validated by the runtime before it runs. Image tags such as `nginx:latest` are rejected; use `image@sha256:<64-hex>`.
+
+## Source configuration
+
+`source_config` separates source origin from runtime specification.
+
+| `source`      | Requirements                                                              |
+| ------------- | ------------------------------------------------------------------------- |
+| `template`    | `template` is required.                                                   |
+| `compose`     | May use local YAML or a repository/provider with a repository and branch. |
+| `application` | `provider_id`, `repository`, `branch`, and `builder` are required.        |
+
+Available application builders are `dockerfile`, `static`, `spa`, and `railpack`. The Git executor resolves a branch to a specific commit and stores that revision on the deployment. Rollback uses the stored revision, not the current branch tip.
+
+## Deployment state
+
+```text
+queued -> preparing -> running -> healthy
+                  \-> failed
+running/healthy -> stopping -> stopped
+healthy -> superseded
+```
+
+The worker only permits valid transitions. Deploy requests use a visible-ASCII idempotency key between 1 and 128 bytes, so a client can retry without creating duplicate deployments.
+
+## Domains and ingress
+
+A domain must be a complete lower-case ASCII hostname, not an IP, `localhost`, wildcard, or public suffix. It starts as `pending`, becomes `active` when the route is applied, and becomes `failed` when route reconciliation fails.
+
+Traefik only discovers containers with the `com.ignitify.managed=true` label. Services with a domain join the `ignitify-proxy` network; the worker manages their routes and labels.
+
+## Events, logs, stop, and rollback
+
+- `POST /api/v1/services/{service_id}/deployments` queues a deployment.
+- `GET /api/v1/deployments/{deployment_id}/events` and `/logs` serve resumable SSE streams.
+- `POST /api/v1/services/{service_id}/stop` requests a stop lifecycle.
+- `POST /api/v1/deployments/{deployment_id}/rollback` queues a deployment from an earlier deployment snapshot/revision.
+
+The worker redacts logs that could contain snapshot values. Do not use build or application output as a channel for exposing secrets.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,62 @@
+# Contribution guide
+
+Contributions should preserve the architecture boundaries and update public contracts when behavior changes.
+
+## Before changing code
+
+- Read `AGENTS.md` in the repository being changed.
+- Check the worktree first; do not discard someone else's changes.
+- Identify the owning layer: domain, persistence, control plane, HTTP, dashboard, or documentation.
+- For cross-layer changes, start with the contract/domain and move toward the UI, not the other way around.
+
+## Backend changes
+
+1. Add tests for new domain, access, persistence, or lifecycle rules.
+2. Use a new numbered SQL migration for persisted data; do not edit migrations that have already been used.
+3. Keep handlers as HTTP adapters and put external side effects in workers/runtime adapters.
+4. Map errors to safe responses and never expose internal details.
+5. Run:
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+## Dashboard changes
+
+1. Update the typed client in `src/lib/api/` before changing a view.
+2. Put reusable behavior in a composable or Pinia store.
+3. Use semantic Tailwind tokens and the existing UI components.
+4. Add a focused Vitest spec for meaningful state/API changes.
+5. From `ignitify/frontend`, run:
+
+```bash
+vp run check
+vp run test
+vp run build
+```
+
+## Documentation changes
+
+- Treat `docs/` as the source content for the public documentation published by
+  the Ignitify marketing site. This repository does not own the VitePress
+  application or its deployment.
+- Keep the default English page and its Indonesian counterpart under `docs/id/`
+  in sync when adding or changing content.
+- Preserve file-based paths and relative links so the marketing repository can
+  mount this directory directly in its VitePress content root.
+- Update the VitePress navigation, theme, language switcher, and documentation
+  build in the marketing repository, together with the content change that
+  requires them.
+- Do not add VitePress dependencies, configuration, generated site output, or
+  marketing-site assets to this control-plane repository.
+
+## Public templates
+
+Template information, changes, and contributions are managed in [xFlawlessDev/ignitify-templates](https://github.com/xFlawlessDev/ignitify-templates). Use that repository as the single source of truth for templates.
+
+## A good pull request
+
+Explain the problem, behavior change, required migration/configuration, and verification performed. Keep unrelated refactors out of the change. If a check cannot run, document the specific limitation instead of claiming it passed.

--- a/docs/guide/development.md
+++ b/docs/guide/development.md
@@ -1,0 +1,70 @@
+# Development
+
+## Repository map
+
+```text
+ignitify/
+  crates/
+    ignitify-core/            Runtime composition and listener
+    ignitify-api/             Axum routes, handlers, DTOs, and HTTP errors
+    ignitify-auth/            Passwords, JWT, and refresh sessions
+    ignitify-db/              SQLite, migrations, models, and repositories
+    ignitify-domain/          Domain types and validation
+    ignitify-control-plane/   Queue, worker, snapshots, and streams
+    ignitify-runtime-*/       Docker and Compose adapters
+    ignitify-ingress-traefik/ Traefik adapter
+    ignitify-source-git/      Git checkout and builder
+    ignitify-terminal/        Host/container PTY
+  frontend/                   Vue 3 administrator dashboard
+  infra/                      Traefik stack and executor documentation
+```
+
+## Architecture boundaries
+
+Backend dependencies flow in one direction: `core -> api -> auth -> db -> domain`. `ignitify-api` may use contracts from database/domain as an adapter, but lower crates must not import HTTP or runtime code.
+
+- Add endpoints in `ignitify-api/src/routes.rs` and handlers in `handlers/<domain>.rs`.
+- Put business validation and I/O-free types in `ignitify-domain`.
+- Add data changes as numbered SQL migrations in `ignitify-db/migrations/` and access them through a repository.
+- External deployment side effects belong in `ignitify-control-plane` and adapter crates, not HTTP handlers.
+- `ignitify-core/src/main.rs` only composes dependencies, workers, and the listener.
+
+## Change workflow
+
+1. Write or update domain validation and its unit tests.
+2. Add a migration when the persistence contract changes.
+3. Change repositories and the control plane before the HTTP handler.
+4. Connect the typed dashboard API client, composable/store, and view.
+5. Add focused tests for authorization, state, persistence, or UI regressions.
+6. Run the quality gate for the changed area.
+
+## Backend conventions
+
+- Rust 2024, typed error enums per crate, and `Result` with `?` for recoverable failures.
+- No `unwrap()` or `expect()` on production paths.
+- SQL uses bind parameters; transactions cover writes that must be atomic.
+- APIs map errors to safe responses. Do not send SQL details, tokens, database URLs, or runtime errors to clients.
+- Split Rust files that grow beyond roughly 800 lines and keep visibility minimal.
+
+## Dashboard conventions
+
+- Use Vue 3 Composition API with `<script setup lang="ts">`.
+- Put HTTP in `src/lib/api/<domain>.ts`; put reusable state and orchestration in a composable or Pinia setup store.
+- Use semantic Tailwind tokens such as `bg-background`, `text-foreground`, and `border-border`.
+- Use components from `src/components/ui/`, `cn()`, and icons from `@lucide/vue`.
+- Every data route must go through `apiFetch` so bearer tokens, refresh, timeouts, and state-changing request headers stay consistent.
+
+## Documentation changes
+
+`docs/` is the source content for the public documentation hosted by the
+separate Ignitify marketing site. It is intentionally not a VitePress project
+in this repository.
+
+Documentation uses file-based paths. Add English Markdown pages under `docs/`
+and Indonesian translations at the matching `docs/id/` path. Keep headings,
+links, and relative asset references portable so the marketing repository can
+consume the content as its VitePress documentation root. Update VitePress
+configuration, locale sidebars, navigation, and the documentation build in the
+marketing repository.
+
+Do not put tokens, passwords, age identities, or real `.env` contents in documentation, examples, snapshots, or screenshots.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,71 @@
+# Getting started locally
+
+Ignitify consists of a control plane (`ignitify/`) and an administrator dashboard (`ignitify/frontend/`). Run the components required for your work.
+
+## Prerequisites
+
+- Rust stable with edition 2024 and Cargo.
+- Node.js 22 or newer and Corepack/pnpm.
+- Docker Engine, Docker Compose v2, and Docker Buildx for running deployments.
+- Git for source builds. Railpack is required for the `railpack` builder.
+
+## Set up the control plane
+
+From the `ignitify` repository root:
+
+```powershell
+Copy-Item .env.example .env
+cargo check --workspace
+cargo test --workspace
+```
+
+`IGNITIFY_JWT_SECRET` and the age identity do not need to be set for development: the backend creates and stores the first runtime secrets in `IGNITIFY_DATA_DIR` (default `data/`). For a persistent environment, set explicit values and protect that data directory.
+
+Run the API when you need a local runtime:
+
+```bash
+cargo run -p ignitify-core
+```
+
+The API listens at `http://127.0.0.1:5656`; the unauthenticated `GET /health` endpoint is available for a basic process check.
+
+## Set up the administrator dashboard
+
+From `ignitify/frontend`:
+
+```bash
+corepack enable
+vp install
+vp run check
+vp run test
+vp dev
+```
+
+The dashboard is available at `http://127.0.0.1:6565` and proxies `/api` to backend port `5656`, including the terminal WebSocket. When the database has no users, the login screen asks you to bootstrap the first administrator.
+
+## First bootstrap
+
+Bootstrap can only happen once. From the dashboard, create the administrator username and password. API clients need a trusted origin and the `X-Ignitify-Request: 1` header for state-changing requests:
+
+```powershell
+$body = @{ username = "admin"; password = "use-a-strong-password" } | ConvertTo-Json
+Invoke-RestMethod -Method Post `
+  -Uri "http://127.0.0.1:5656/api/v1/auth/bootstrap" `
+  -Headers @{ Origin = "http://127.0.0.1:6565"; "X-Ignitify-Request" = "1" } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+Keep the access token returned by the response in client memory only. The server manages the refresh token as an HttpOnly cookie.
+
+## Recommended checks
+
+| Area                       | Command                                                 |
+| -------------------------- | ------------------------------------------------------- |
+| Rust format                | `cargo fmt --all -- --check`                            |
+| Rust lint                  | `cargo clippy --workspace --all-targets -- -D warnings` |
+| Rust tests                 | `cargo test --workspace`                                |
+| Dashboard format/lint/type | `vp run check` from `ignitify/frontend`                 |
+| Dashboard tests            | `vp run test` from `ignitify/frontend`                  |
+
+Continue to [configuration](/operations/configuration) before enabling Docker, ingress, or Git repository builds.

--- a/docs/id/concepts/architecture.md
+++ b/docs/id/concepts/architecture.md
@@ -1,0 +1,61 @@
+# Arsitektur
+
+Ignitify memisahkan HTTP, domain, persistence, dan external side effect. Pemisahan ini menjaga handler tetap tipis, membuat validasi dapat diuji tanpa runtime Docker, dan membatasi tempat yang memiliki akses ke rahasia atau host.
+
+## Komponen runtime
+
+```text
+Browser dashboard
+  -> Vue Router / Pinia / typed API client
+  -> Vite proxy pada pengembangan
+  -> Axum API
+       -> AuthService + SQLite repositories
+       -> ServiceControl / ControlHandle
+       -> deployment worker
+            -> Docker runtime atau Compose runtime
+            -> Git source builder
+            -> Traefik ingress
+```
+
+`ignitify-core` membaca konfigurasi, membuat secret runtime bila perlu, membuka SQLite, membuat adapter Docker/Compose/Traefik/Git, lalu memulai worker dan router Axum. Listener default adalah `127.0.0.1:5656`.
+
+## Crate dan tanggung jawab
+
+| Crate                      | Tanggung jawab                                                                    |
+| -------------------------- | --------------------------------------------------------------------------------- |
+| `ignitify-core`            | Composition root, listener, secret runtime, dan readiness dependency.             |
+| `ignitify-api`             | Route, HTTP DTO, extract auth/origin, cookie, stream SSE, dan mapping error aman. |
+| `ignitify-auth`            | Argon2 password, JWT access token, refresh token berotasi, dan session.           |
+| `ignitify-db`              | Pool SQLite, embedded migration, model persistence, dan repository berotorisasi.  |
+| `ignitify-domain`          | Identifier, service spec, status deployment/domain, dan aturan input.             |
+| `ignitify-control-plane`   | Enkripsi environment, submit deployment, worker, lifecycle, event/log stream.     |
+| `ignitify-runtime-docker`  | Inventaris, metric, aksi kontainer, dan runtime image OCI.                        |
+| `ignitify-runtime-compose` | Validasi dan lifecycle service Compose.                                           |
+| `ignitify-ingress-traefik` | Jaringan dan label Traefik untuk domain service.                                  |
+| `ignitify-source-git`      | Checkout source, resolusi commit, dan builder Dockerfile/static/Railpack.         |
+| `ignitify-terminal`        | Terminal PTY yang diproteksi untuk host dan kontainer.                            |
+
+## Data yang bertahan
+
+SQLite menyimpan user, refresh token hash, project dan membership, service, deployment, domain, activity, provider, serta konfigurasi source. Migrasi ada di `ignitify-db/migrations/` dan di-embed oleh crate database.
+
+Nilai environment project dan service tidak disimpan sebagai plaintext. `ServiceControl` mengenkripsi nilai dengan age, menggunakan identity runtime yang disimpan terpisah dari database. Saat dibaca, nilai secret tetap dimask; nilai non-secret hanya dapat dibuka bagi peran yang dapat mengelola service.
+
+## Otorisasi
+
+Autentikasi menghasilkan `AuthenticatedUser` dengan peran `admin` atau `user`. Di dalam project, peran membership adalah:
+
+| Peran    | Izin                                                         |
+| -------- | ------------------------------------------------------------ |
+| `owner`  | Mengubah project dan mengelola service/environment.          |
+| `editor` | Mengelola service/environment, tanpa mengubah project.       |
+| `viewer` | Membaca resource yang dapat diakses.                         |
+| `admin`  | Akses lintas project dan operasi host yang dilindungi admin. |
+
+Repository menerima actor dan mengevaluasi akses sebelum menghasilkan data. Handler tidak boleh mengandalkan penyaringan UI untuk menerapkan akses.
+
+## Observability dan health
+
+`GET /health` adalah probe dasar tanpa autentikasi. `GET /api/v1/runtime/status` memeriksa database, runtime, worker, ingress, dan metric host sebagai status `ready` atau `unavailable`. Metric sistem detail ada pada `GET /api/v1/runtime/metrics`; inventaris Docker tersedia melalui endpoint runtime.
+
+Event dan log deployment menggunakan SSE. Stream dapat melakukan replay dari cursor yang disimpan (`Last-Event-ID` atau `after`) dan mengirim snapshot jika cursor client lebih tua dari retensi event.

--- a/docs/id/concepts/deployment-lifecycle.md
+++ b/docs/id/concepts/deployment-lifecycle.md
@@ -1,0 +1,63 @@
+# Siklus deployment
+
+## Model resource
+
+Sebuah project memiliki default environment dan banyak service. Service memiliki konfigurasi runtime, variabel, optional source configuration, dan desired generation/state. Deployment adalah snapshot immutable dari service dan environment pada saat request diterima.
+
+```text
+Project environment
+       +
+Service variables
+       |
+       v
+encrypted deployment snapshot -> queue -> worker -> runtime + ingress
+```
+
+Nilai environment project digabung terlebih dahulu, lalu variabel service dengan key yang sama menimpa nilainya. Snapshot deployment dienkripsi sebelum disimpan. Perubahan environment berikutnya tidak mengubah deployment yang telah disubmit.
+
+## Jenis service
+
+| Jenis     | Konfigurasi                                                                                         |
+| --------- | --------------------------------------------------------------------------------------------------- |
+| `image`   | Reference OCI yang wajib dipin ke digest SHA-256, optional internal port dan healthcheck exec-form. |
+| `compose` | YAML Compose, nama service yang diekspos, dan optional internal port.                               |
+
+Nama service dan exposed Compose service harus berupa DNS label lower-case. YAML Compose dibatasi 1 MiB dan divalidasi oleh runtime sebelum dijalankan. Image tag seperti `nginx:latest` ditolak; gunakan `image@sha256:<64-hex>`.
+
+## Source configuration
+
+`source_config` memisahkan asal source dari spesifikasi runtime.
+
+| `source`      | Kebutuhan                                                                       |
+| ------------- | ------------------------------------------------------------------------------- |
+| `template`    | `template` wajib diisi.                                                         |
+| `compose`     | Dapat memakai YAML lokal atau repository/provider dengan repository dan branch. |
+| `application` | `provider_id`, `repository`, `branch`, dan `builder` wajib diisi.               |
+
+Builder aplikasi yang tersedia adalah `dockerfile`, `static`, `spa`, dan `railpack`. Git executor menyelesaikan branch ke commit tertentu dan menyimpan revisi tersebut pada deployment. Rollback memakai revisi tersimpan, bukan tip branch saat ini.
+
+## State deployment
+
+```text
+queued -> preparing -> running -> healthy
+                  \-> failed
+running/healthy -> stopping -> stopped
+healthy -> superseded
+```
+
+Worker hanya mengizinkan transisi yang sah. Permintaan deploy memakai idempotency key terlihat-ASCII dengan panjang 1 sampai 128 byte, sehingga client dapat mengulang submit tanpa membuat deployment ganda.
+
+## Domain dan ingress
+
+Domain harus berupa hostname ASCII lower-case lengkap, bukan IP, `localhost`, wildcard, atau public suffix. Domain mulai dalam status `pending`, menjadi `active` ketika route berhasil diterapkan, dan menjadi `failed` ketika rekonsiliasi route gagal.
+
+Traefik hanya menemukan kontainer dengan label `com.ignitify.managed=true`. Service yang memiliki domain bergabung ke jaringan `ignitify-proxy`; route dan labelnya dikelola worker.
+
+## Event, log, stop, dan rollback
+
+- `POST /api/v1/services/{service_id}/deployments` mengantrekan deployment.
+- `GET /api/v1/deployments/{deployment_id}/events` dan `/logs` menyajikan SSE yang dapat di-resume.
+- `POST /api/v1/services/{service_id}/stop` meminta lifecycle berhenti.
+- `POST /api/v1/deployments/{deployment_id}/rollback` mengantrekan deployment dari snapshot/revisi deployment sebelumnya.
+
+Log yang berpotensi mengandung nilai snapshot akan disensor oleh worker. Jangan gunakan output build atau aplikasi sebagai kanal untuk mengungkap secret.

--- a/docs/id/contributing.md
+++ b/docs/id/contributing.md
@@ -1,0 +1,61 @@
+# Panduan kontribusi
+
+Kontribusi harus mempertahankan batas arsitektur dan memperbarui kontrak publik ketika perilaku berubah.
+
+## Sebelum mengubah kode
+
+- Baca `AGENTS.md` pada repository yang diubah.
+- Periksa worktree terlebih dahulu; jangan membatalkan perubahan milik orang lain.
+- Tentukan layer pemilik perubahan: domain, persistence, control plane, HTTP, dashboard, atau dokumentasi.
+- Untuk perubahan antar layer, mulai dari kontrak/domain dan bergerak ke arah UI, bukan sebaliknya.
+
+## Perubahan backend
+
+1. Tambahkan test untuk aturan domain, akses, persistence, atau lifecycle baru.
+2. Gunakan migrasi SQL baru bernomor untuk data yang bertahan; jangan mengedit migrasi yang sudah dipakai.
+3. Jaga handler sebagai adapter HTTP dan letakkan external side effect di worker/runtime adapter.
+4. Map error ke respons aman dan jangan bocorkan detail internal.
+5. Jalankan:
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+## Perubahan dashboard
+
+1. Ubah typed client di `src/lib/api/` sebelum view.
+2. Tempatkan perilaku reusable dalam composable atau Pinia store.
+3. Gunakan token Tailwind semantik dan komponen UI yang ada.
+4. Tambahkan spec Vitest untuk perubahan state/API yang bermakna.
+5. Dari `ignitify/frontend`, jalankan:
+
+```bash
+vp run check
+vp run test
+vp run build
+```
+
+## Perubahan dokumentasi
+
+- Perlakukan `docs/` sebagai sumber konten untuk dokumentasi publik yang
+  diterbitkan oleh situs marketing Ignitify. Repository ini tidak memiliki
+  aplikasi VitePress maupun deployment-nya.
+- Pertahankan halaman English sebagai default dan pasangan Indonesia di bawah
+  `docs/id/` tetap sinkron saat menambah atau mengubah konten.
+- Pertahankan path berbasis file dan relative link agar repository marketing
+  dapat memasang direktori ini langsung ke content root VitePress-nya.
+- Perbarui navigasi VitePress, tema, language switcher, dan build dokumentasi
+  pada repository marketing, bersama perubahan konten yang membutuhkannya.
+- Jangan menambahkan dependency VitePress, konfigurasi, output site hasil
+  generate, atau aset situs marketing ke repository control plane ini.
+
+## Template publik
+
+Informasi, perubahan, dan kontribusi template dikelola di [xFlawlessDev/ignitify-templates](https://github.com/xFlawlessDev/ignitify-templates). Gunakan repository tersebut sebagai sumber tunggal untuk template.
+
+## Pull request yang baik
+
+Jelaskan masalah, perubahan perilaku, migration/konfigurasi yang diperlukan, dan verifikasi yang dijalankan. Pisahkan refactor yang tidak relevan dari perubahan fungsional. Jika pengujian tidak dapat dijalankan, catat batasannya secara spesifik daripada mengklaim lolos.

--- a/docs/id/guide/development.md
+++ b/docs/id/guide/development.md
@@ -1,0 +1,69 @@
+# Pengembangan
+
+## Peta repository
+
+```text
+ignitify/
+  crates/
+    ignitify-core/             Komposisi runtime dan listener
+    ignitify-api/              Axum routes, handler, DTO, HTTP error
+    ignitify-auth/             Password, JWT, refresh session
+    ignitify-db/               SQLite, migrasi, model, repository
+    ignitify-domain/           Tipe domain dan validasi
+    ignitify-control-plane/    Queue, worker, snapshot, stream
+    ignitify-runtime-*/        Adapter Docker dan Compose
+    ignitify-ingress-traefik/  Adapter Traefik
+    ignitify-source-git/       Checkout dan builder Git
+    ignitify-terminal/         PTY host/container
+  frontend/                    Dashboard Vue 3
+  infra/                       Stack Traefik dan dokumentasi executor
+```
+
+## Batas arsitektur
+
+Dependency backend mengalir satu arah: `core -> api -> auth -> db -> domain`. `ignitify-api` boleh memakai kontrak dari database/domain sebagai adapter, tetapi crate yang lebih rendah tidak boleh mengimpor HTTP atau runtime.
+
+- Tambahkan endpoint pada `ignitify-api/src/routes.rs` dan handler pada `handlers/<domain>.rs`.
+- Letakkan validasi bisnis dan tipe yang bebas I/O di `ignitify-domain`.
+- Tambahkan perubahan data sebagai migrasi SQL bernomor di `ignitify-db/migrations/` dan akses melalui repository.
+- External side effect deployment berada di `ignitify-control-plane` dan crate adapter, bukan handler HTTP.
+- `ignitify-core/src/main.rs` hanya menyusun dependency, worker, dan listener.
+
+## Workflow perubahan
+
+1. Tulis atau perbarui validasi domain dan test unitnya.
+2. Tambahkan migrasi jika kontrak persistence berubah.
+3. Ubah repository dan service/control plane sebelum handler HTTP.
+4. Hubungkan typed API client, composable, store, lalu view dashboard.
+5. Tambahkan test focused untuk otorisasi, state, persistence, atau regresi UI.
+6. Jalankan quality gate untuk area yang berubah.
+
+## Konvensi backend
+
+- Rust 2024, error enum bertipe per crate, dan `Result` dengan `?` untuk kegagalan yang dapat dipulihkan.
+- Tidak ada `unwrap()` atau `expect()` pada path produksi.
+- SQL memakai bind parameter; transaksi melingkupi write yang harus atomik.
+- API hanya memetakan error menjadi respons aman. Detail SQL, token, URL database, atau kesalahan runtime tidak boleh dikirim ke client.
+- Pecah file Rust yang mulai melewati sekitar 800 baris, dan pertahankan visibility minimum.
+
+## Konvensi dashboard
+
+- Gunakan Vue 3 Composition API dengan `<script setup lang="ts">`.
+- HTTP berada di `src/lib/api/<domain>.ts`; state dan orkestrasi reusable berada di composable atau Pinia setup store.
+- Pakai token Tailwind semantik seperti `bg-background`, `text-foreground`, dan `border-border`.
+- Gunakan komponen dari `src/components/ui/`, `cn()`, dan ikon `@lucide/vue`.
+- Semua route yang membutuhkan data harus melewati `apiFetch`, sehingga Bearer token, refresh, timeout, dan header request state-changing konsisten.
+
+## Perubahan dokumentasi
+
+`docs/` adalah sumber konten untuk dokumentasi publik yang di-host oleh situs
+marketing Ignitify terpisah. Repository ini sengaja bukan project VitePress.
+
+Dokumentasi menggunakan path berbasis file. Tambahkan halaman Markdown English
+di `docs/` dan terjemahan Indonesia pada path yang sesuai di `docs/id/`.
+Pertahankan heading, link, dan referensi aset relatif agar repository marketing
+dapat memakai konten ini sebagai root dokumentasi VitePress-nya. Perbarui
+konfigurasi VitePress, sidebar locale, navigasi, dan build dokumentasi di
+repository marketing.
+
+Jangan menuliskan token, password, identity age, atau isi `.env` yang nyata ke dokumen, contoh, snapshot, maupun screenshot.

--- a/docs/id/guide/getting-started.md
+++ b/docs/id/guide/getting-started.md
@@ -1,0 +1,71 @@
+# Memulai secara lokal
+
+Ignitify terdiri dari control plane (`ignitify/`) dan dashboard administrator (`ignitify/frontend/`). Jalankan komponen yang diperlukan untuk pekerjaan Anda.
+
+## Prasyarat
+
+- Rust stable dengan edition 2024 dan Cargo.
+- Node.js 22 atau lebih baru dan Corepack/pnpm.
+- Docker Engine, Docker Compose v2, dan Docker Buildx untuk menjalankan deployment.
+- Git untuk source build. Railpack dibutuhkan untuk builder `railpack`.
+
+## Siapkan control plane
+
+Dari root repository `ignitify`:
+
+```powershell
+Copy-Item .env.example .env
+cargo check --workspace
+cargo test --workspace
+```
+
+`IGNITIFY_JWT_SECRET` dan identitas age tidak wajib disetel untuk pengembangan: backend membuat dan menyimpan rahasia runtime pertama kali di `IGNITIFY_DATA_DIR` (default `data/`). Untuk lingkungan yang bertahan lama, set nilai eksplisit dan lindungi direktori data tersebut.
+
+Jalankan API saat Anda memang membutuhkan runtime lokal:
+
+```bash
+cargo run -p ignitify-core
+```
+
+API mendengarkan `http://127.0.0.1:5656`; pemeriksaan tanpa autentikasi tersedia di `GET /health`.
+
+## Siapkan dashboard administrator
+
+Dari `ignitify/frontend`:
+
+```bash
+corepack enable
+vp install
+vp run check
+vp run test
+vp dev
+```
+
+Dashboard tersedia di `http://127.0.0.1:6565` dan mem-proxy `/api` ke port backend `5656`, termasuk WebSocket terminal. Ketika database belum memiliki pengguna, layar login meminta bootstrap administrator pertama.
+
+## Bootstrap pertama
+
+Bootstrap hanya dapat dilakukan sekali. Dari dashboard, buat username dan password admin. Untuk client API, request state-changing memerlukan origin tepercaya dan header `X-Ignitify-Request: 1`:
+
+```powershell
+$body = @{ username = "admin"; password = "gunakan-password-kuat" } | ConvertTo-Json
+Invoke-RestMethod -Method Post `
+  -Uri "http://127.0.0.1:5656/api/v1/auth/bootstrap" `
+  -Headers @{ Origin = "http://127.0.0.1:6565"; "X-Ignitify-Request" = "1" } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+Simpan access token hasil respons hanya di memori client. Refresh token dikelola sebagai cookie HttpOnly oleh server.
+
+## Pemeriksaan yang direkomendasikan
+
+| Area                       | Perintah                                                |
+| -------------------------- | ------------------------------------------------------- |
+| Rust format                | `cargo fmt --all -- --check`                            |
+| Rust lint                  | `cargo clippy --workspace --all-targets -- -D warnings` |
+| Rust test                  | `cargo test --workspace`                                |
+| Dashboard format/lint/type | `vp run check` dari `ignitify/frontend`                 |
+| Dashboard test             | `vp run test` dari `ignitify/frontend`                  |
+
+Lanjutkan ke [konfigurasi](/id/operations/configuration) sebelum mengaktifkan Docker, ingress, atau build dari repository Git.

--- a/docs/id/index.md
+++ b/docs/id/index.md
@@ -1,0 +1,33 @@
+# Ignitify
+
+Ignitify adalah control plane self-hosted untuk menjalankan aplikasi, layanan Compose, dan image OCI pada infrastruktur sendiri. Dokumentasi ini menjelaskan implementasi yang ada saat ini, bukan roadmap.
+
+## Mulai dari sini
+
+- [Memulai secara lokal](/id/guide/getting-started) untuk menyiapkan backend dan dashboard.
+- [Arsitektur](/id/concepts/architecture) untuk memahami batas setiap crate dan aliran data.
+- [Siklus deployment](/id/concepts/deployment-lifecycle) untuk memahami service, environment, domain, dan worker.
+- [Referensi API](/id/reference/api) untuk seluruh route HTTP yang terdaftar.
+- [Ignitify Templates](https://github.com/xFlawlessDev/ignitify-templates) untuk daftar template dan kontribusi template publik.
+
+## Kapabilitas saat ini
+
+| Area        | Kemampuan                                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Akses       | Bootstrap admin sekali, login, access token JWT, dan refresh token berbasis cookie.                                                         |
+| Workspace   | Project SQLite, peran owner/editor/viewer, service, environment, activity, dan dashboard.                                                   |
+| Deployment  | Image OCI yang dipin ke digest, Compose tervalidasi, source Git untuk aplikasi atau Compose, queue worker, rollback, event, dan log stream. |
+| Operasional | Status runtime, metric host/container, inventaris dan tindakan Docker admin, serta terminal host/container admin.                           |
+| Ingress     | Traefik operator, domain service, TLS ACME, dan jaringan `ignitify-proxy`.                                                                  |
+
+## Bagian repository
+
+```text
+ignitify/       Control plane Rust dan dashboard administrator Vue
+```
+
+Dashboard administrator berada di `ignitify/frontend`.
+
+## Status operasional
+
+Backend secara default hanya mendengarkan `127.0.0.1:5656`; dashboard pengembangan berada di port `6565`. Eksposur publik harus melalui reverse proxy atau operator ingress yang dikonfigurasi dengan sengaja. Lihat [konfigurasi](/id/operations/configuration) dan [keamanan](/id/reference/security) sebelum menjalankan pada host yang dapat diakses publik.

--- a/docs/id/operations/configuration.md
+++ b/docs/id/operations/configuration.md
@@ -1,0 +1,42 @@
+# Konfigurasi
+
+Simpan override backend di `ignitify/.env`; mulai dari `.env.example`. File berisi secret dan tidak boleh masuk Git.
+
+## Backend dasar
+
+| Variabel                        | Default                                       | Kegunaan                                               |
+| ------------------------------- | --------------------------------------------- | ------------------------------------------------------ |
+| `IGNITIFY_DATABASE_URL`         | `sqlite:data/ignitify.db`                     | Lokasi database SQLite.                                |
+| `IGNITIFY_DATA_DIR`             | `data`                                        | Direktori secret runtime dan data lokal.               |
+| `IGNITIFY_JWT_SECRET`           | dibuat saat start pertama                     | Secret JWT minimal 32 karakter untuk nilai eksplisit.  |
+| `IGNITIFY_SECRETS_AGE_IDENTITY` | dibuat saat start pertama                     | Identity age untuk enkripsi configuration/environment. |
+| `IGNITIFY_SECURE_COOKIES`       | `false`                                       | Set `true` bila dashboard diakses lewat HTTPS.         |
+| `IGNITIFY_TRUSTED_ORIGINS`      | `http://localhost:6565,http://127.0.0.1:6565` | Daftar origin dashboard yang dipisahkan koma.          |
+
+Backend mengikat listener ke `127.0.0.1:5656` pada implementasi saat ini. Gunakan reverse proxy lokal atau ubah implementasi secara sengaja bila perlu menerima koneksi dari interface lain. Jangan sekadar membuka firewall lalu menganggap layanan tersedia dari jaringan lain.
+
+## Docker dan Compose
+
+| Variabel                        | Kegunaan                                                   |
+| ------------------------------- | ---------------------------------------------------------- |
+| `IGNITIFY_DOCKER_HOST`          | Override endpoint Docker, misalnya `tcp://127.0.0.1:2375`. |
+| `IGNITIFY_DOCKER_BIN`           | Path executable Docker bila tidak tersedia pada `PATH`.    |
+| `IGNITIFY_COMPOSE_ROOT`         | Root untuk material Compose yang dikelola runtime.         |
+| `IGNITIFY_AUTO_START_INGRESS`   | Set `false` bila Traefik dikelola operator eksternal.      |
+| `IGNITIFY_TRAEFIK_COMPOSE_FILE` | Path Compose operator Traefik.                             |
+| `IGNITIFY_ACME_EMAIL`           | Kontak ACME untuk sertifikat produksi.                     |
+
+Jika memakai socket Docker, batasi akses proses Ignitify. Docker memberikan kemampuan tinggi pada host; dashboard dan API control plane harus diperlakukan sebagai permukaan administratif.
+
+## Source build Git
+
+| Variabel                           | Kegunaan                                             |
+| ---------------------------------- | ---------------------------------------------------- |
+| `IGNITIFY_SOURCE_BUILD_ROOT`       | Direktori sementara checkout source.                 |
+| `IGNITIFY_GIT_BIN`                 | Path Git.                                            |
+| `IGNITIFY_RAILPACK_BIN`            | Path binary Railpack.                                |
+| `IGNITIFY_STATIC_BUILD_IMAGE`      | Builder Node yang dipin digest untuk static build.   |
+| `IGNITIFY_STATIC_RUNTIME_IMAGE`    | Runtime Caddy yang dipin digest untuk static output. |
+| `IGNITIFY_RAILPACK_FRONTEND_IMAGE` | Frontend Railpack yang dipin digest.                 |
+
+Nilai default builder/runtime sudah dibundel. Override hanya saat mengganti release yang telah direview. Host build harus menyediakan Git dan Docker Buildx; produksi sebaiknya memakai build host khusus dan quota Docker.

--- a/docs/id/operations/ingress-and-domains.md
+++ b/docs/id/operations/ingress-and-domains.md
@@ -1,0 +1,41 @@
+# Ingress dan domain
+
+Ignitify menggunakan operator Traefik untuk mengekspos service yang mempunyai domain. Stack operator berada di `ignitify/infra/traefik/` dan dapat dimulai otomatis oleh backend kecuali `IGNITIFY_AUTO_START_INGRESS=false`.
+
+## Prasyarat produksi
+
+1. Host harus menjalankan Docker dan dapat membuat jaringan `ignitify-proxy`.
+2. DNS A/AAAA setiap domain harus menunjuk ke host ingress.
+3. Port HTTP/HTTPS untuk Traefik harus tersedia pada perimeter host.
+4. `IGNITIFY_ACME_EMAIL` harus menggunakan alamat kontak nyata sebelum meminta sertifikat.
+5. Dashboard Traefik tetap nonaktif; jangan mengaktifkannya tanpa autentikasi dan network policy yang sesuai.
+
+Untuk operator yang dikelola manual, jalankan dari root `ignitify`:
+
+```bash
+docker compose --env-file infra/traefik/.env -f infra/traefik/compose.yaml up -d
+```
+
+Setelah backend dimulai, `GET /api/v1/runtime/status` harus menunjukkan `"ingress":"ready"` untuk user yang sudah terautentikasi.
+
+## Menambahkan domain
+
+1. Buat atau pilih service yang mempunyai `internal_port`.
+2. Tambahkan hostname lengkap seperti `app.example.com` melalui dashboard atau `POST /api/v1/services/{service_id}/domains`.
+3. Pastikan DNS selesai mengarah ke host sebelum mengharapkan TLS ACME.
+4. Deploy ulang service bila perlu agar worker menerapkan route.
+5. Pantau domain melalui daftar domain service dan event deployment.
+
+Hostname harus ASCII lower-case, memiliki setidaknya satu titik, dan bukan wildcard, IP, `localhost`, maupun public suffix seperti `co.uk`.
+
+## Diagnostik
+
+| Gejala                        | Pemeriksaan                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| Ingress unavailable           | Periksa Docker, stack Traefik, konfigurasi compose, dan status `ingress`.        |
+| Domain tetap pending          | Periksa deployment/event, nama domain, DNS, dan port internal service.           |
+| Domain failed                 | Periksa event deployment; kegagalan rekonsiliasi route menandai domain `failed`. |
+| TLS tidak terbit              | Periksa DNS publik, port 80/443, dan `IGNITIFY_ACME_EMAIL`.                      |
+| Service tidak ditemukan proxy | Pastikan service dikelola Ignitify dan terhubung ke `ignitify-proxy`.            |
+
+Jangan menambahkan label Traefik manual ke kontainer Ignitify-managed. Worker memiliki ownership atas label dan dapat menimpa konfigurasi manual saat rekonsiliasi berikutnya.

--- a/docs/id/reference/api.md
+++ b/docs/id/reference/api.md
@@ -1,0 +1,116 @@
+# API control plane
+
+Base URL local: `http://127.0.0.1:5656`. Semua route control plane berada di bawah `/api/v1`, kecuali `GET /health`.
+
+## Konvensi
+
+- Request dan respons memakai JSON kecuali upload multipart, SSE, dan WebSocket terminal.
+- Route terproteksi membutuhkan `Authorization: Bearer <access-token>`.
+- Request yang mengubah state juga membutuhkan `X-Ignitify-Request: 1` dan `Origin` yang ada dalam `IGNITIFY_TRUSTED_ORIGINS`.
+- Respons error tidak mengungkap detail database, token, atau runtime. Status `400`, `401`, `403`, `404`, `409`, dan `500` mengikuti kelas kegagalan umum.
+- Identifier resource adalah UUID. Gunakan idempotency key ketika membuat deployment.
+
+## Autentikasi
+
+| Method | Path                     | Auth   | Keterangan                                               |
+| ------ | ------------------------ | ------ | -------------------------------------------------------- |
+| `GET`  | `/health`                | Tidak  | Probe proses dasar.                                      |
+| `GET`  | `/api/v1/auth/bootstrap` | Tidak  | Memeriksa apakah admin pertama diperlukan.               |
+| `POST` | `/api/v1/auth/bootstrap` | Tidak  | Membuat admin pertama; hanya sekali.                     |
+| `POST` | `/api/v1/auth/login`     | Tidak  | Membuat session dan refresh cookie.                      |
+| `POST` | `/api/v1/auth/refresh`   | Cookie | Memutar refresh token dan menerbitkan access token baru. |
+| `POST` | `/api/v1/auth/logout`    | Cookie | Mencabut refresh session dan menghapus cookie.           |
+| `GET`  | `/api/v1/auth/me`        | Ya     | Mengembalikan user saat ini.                             |
+
+Body bootstrap/login memakai `{ "username": "...", "password": "..." }`. Respons session berisi `access_token`, `token_type`, `expires_at`, dan `user`; cookie refresh dikirim dengan `Set-Cookie`.
+
+## Dashboard dan provider
+
+| Method            | Path                                           | Keterangan                                              |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------- |
+| `GET`             | `/api/v1/dashboard`                            | Ringkasan project, service, dan deployment untuk actor. |
+| `GET`, `POST`     | `/api/v1/providers`                            | List atau buat provider source.                         |
+| `POST`            | `/api/v1/providers/github/manifest`            | Memulai GitHub App manifest flow.                       |
+| `GET`             | `/api/v1/providers/github/manifest/callback`   | Callback manifest GitHub.                               |
+| `PATCH`, `DELETE` | `/api/v1/providers/{provider_id}`              | Ubah atau hapus provider.                               |
+| `POST`            | `/api/v1/providers/{provider_id}/test`         | Uji koneksi provider.                                   |
+| `GET`             | `/api/v1/providers/{provider_id}/repositories` | Daftar repository yang dapat diakses.                   |
+| `GET`             | `/api/v1/providers/{provider_id}/branches`     | Daftar branch untuk repository provider.                |
+
+Provider credential dienkripsi pada backend. GitHub App manifest flow dan provider discovery tidak berarti setiap credential provider dapat dipakai oleh executor build; executor Git saat ini tidak mendukung GitHub App credential.
+
+## Runtime dan terminal
+
+| Method   | Path                                                 | Akses | Keterangan                                                      |
+| -------- | ---------------------------------------------------- | ----- | --------------------------------------------------------------- |
+| `GET`    | `/api/v1/runtime/status`                             | User  | Readiness database/runtime/worker/ingress dan ringkasan metric. |
+| `GET`    | `/api/v1/runtime/metrics`                            | User  | CPU, memori, disk, network, dan metric container.               |
+| `GET`    | `/api/v1/runtime/containers`                         | User  | Inventaris kontainer bila runtime tersedia.                     |
+| `GET`    | `/api/v1/runtime/containers/{container_id}/details`  | Admin | Detail konfigurasi, mount, network, dan label.                  |
+| `GET`    | `/api/v1/runtime/containers/{container_id}/logs`     | Admin | Log kontainer.                                                  |
+| `POST`   | `/api/v1/runtime/containers/{container_id}/upload`   | Admin | Upload multipart, maksimum 8 MiB.                               |
+| `DELETE` | `/api/v1/runtime/containers/{container_id}`          | Admin | Menghapus kontainer.                                            |
+| `GET`    | `/api/v1/terminal`                                   | Admin | Upgrade WebSocket terminal host.                                |
+| `GET`    | `/api/v1/runtime/containers/{container_id}/terminal` | Admin | Upgrade WebSocket terminal kontainer.                           |
+
+Upload menerima field multipart `file` dan optional `destination` (default `/tmp`). Terminal melakukan autentikasi dan validasi origin pada WebSocket; gunakan client dashboard sebagai referensi protokol.
+
+## Project, environment, dan service
+
+| Method                   | Path                                        | Keterangan                                         |
+| ------------------------ | ------------------------------------------- | -------------------------------------------------- |
+| `GET`, `POST`            | `/api/v1/projects`                          | List project yang dapat diakses atau buat project. |
+| `GET`, `PATCH`           | `/api/v1/projects/{project_id}`             | Detail atau ubah project.                          |
+| `GET`, `PUT`             | `/api/v1/projects/{project_id}/environment` | Baca atau ganti environment default project.       |
+| `GET`                    | `/api/v1/projects/{project_id}/deployments` | Deployment seluruh service project.                |
+| `GET`                    | `/api/v1/projects/{project_id}/activity`    | Activity project.                                  |
+| `GET`, `POST`            | `/api/v1/projects/{project_id}/services`    | List atau buat service.                            |
+| `GET`, `PATCH`, `DELETE` | `/api/v1/services/{service_id}`             | Baca, ubah, atau hapus service.                    |
+| `GET`, `POST`            | `/api/v1/services/{service_id}/domains`     | List atau tambahkan domain.                        |
+| `DELETE`                 | `/api/v1/domains/{domain_id}`               | Hapus domain dengan konfirmasi.                    |
+
+Contoh request service image:
+
+```json
+{
+  "name": "web",
+  "kind": "image",
+  "image_reference": "nginx@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "internal_port": 8080,
+  "healthcheck": ["/bin/sh", "-c", "wget -qO- http://localhost:8080/health"],
+  "variables": [
+    { "key": "LOG_LEVEL", "value": "info", "is_secret": false },
+    { "key": "DATABASE_URL", "value": "secret", "is_secret": true }
+  ]
+}
+```
+
+Untuk service Compose, gunakan `kind: "compose"`, `compose_yaml`, `exposed_service`, `internal_port`, dan `variables`. `source_config` dapat ditambahkan untuk template, Git Compose, atau application source. Nilai secret respons tidak dikembalikan sebagai plaintext.
+
+Environment project memakai bentuk berikut. Untuk mempertahankan secret yang sudah ada, kirim `value: null` dengan `is_secret: true`; nilai baru diperlukan untuk variable non-secret.
+
+```json
+{
+  "variables": [
+    { "key": "REGION", "value": "id", "is_secret": false },
+    { "key": "API_KEY", "value": null, "is_secret": true }
+  ]
+}
+```
+
+## Deployment dan stream
+
+| Method        | Path                                           | Keterangan                                      |
+| ------------- | ---------------------------------------------- | ----------------------------------------------- |
+| `GET`, `POST` | `/api/v1/services/{service_id}/deployments`    | List deployment service atau submit deployment. |
+| `POST`        | `/api/v1/services/{service_id}/stop`           | Meminta penghentian service.                    |
+| `GET`         | `/api/v1/deployments/{deployment_id}`          | Detail deployment.                              |
+| `POST`        | `/api/v1/deployments/{deployment_id}/rollback` | Submit rollback dari snapshot deployment.       |
+| `GET`         | `/api/v1/deployments/{deployment_id}/events`   | SSE event lifecycle.                            |
+| `GET`         | `/api/v1/deployments/{deployment_id}/logs`     | SSE line log.                                   |
+
+Submit deployment membutuhkan header idempotency key sesuai kontrak client. Untuk melanjutkan SSE, kirim `Last-Event-ID` atau parameter query `after=<sequence>`. Stream mengirim event `snapshot` jika cursor lebih lama dari data yang masih tersedia, heartbeat sekitar 15 detik, dan event `log` untuk stream log.
+
+## Sumber kontrak
+
+Daftar route di atas berasal dari `ignitify/crates/ignitify-api/src/routes.rs`. DTO respons dan validasi spesifik berada pada `handlers/` dan `ignitify-domain`. Saat mengubah kontrak, perbarui route, typed client dashboard, test, dan halaman ini dalam satu perubahan.

--- a/docs/id/reference/security.md
+++ b/docs/id/reference/security.md
@@ -1,0 +1,40 @@
+# Keamanan
+
+Ignitify adalah control plane yang dapat mengakses Docker, source build, ingress, dan terminal. Perlakukan sebagai sistem administratif, bukan aplikasi publik biasa.
+
+## Kontrol yang diterapkan
+
+| Area            | Kontrol                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| Password        | Hash Argon2; password plaintext tidak dipersist.                                                    |
+| Access session  | JWT berumur 15 menit; dashboard menyimpan access token di memori.                                   |
+| Refresh session | Cookie HttpOnly, token yang disimpan sebagai hash, rotasi, dan deteksi reuse yang mencabut family.  |
+| CSRF/origin     | Endpoint state-changing memeriksa `X-Ignitify-Request` dan origin tepercaya.                        |
+| Secret config   | Environment project/service dan credential provider dienkripsi age.                                 |
+| Secret output   | Nilai secret disamarkan pada read model; worker menyensor log yang dapat memuat snapshot value.     |
+| Otorisasi       | Project role diverifikasi repository; tindakan Docker dan terminal memerlukan admin.                |
+| Runtime image   | Image service wajib memakai digest SHA-256.                                                         |
+| Compose         | Policy menolak configuration yang tidak didukung/berisiko sebelum submission.                       |
+| Ingress         | Traefik hanya melihat kontainer berlabel `com.ignitify.managed=true`; dashboard operator dimatikan. |
+
+## Checklist produksi
+
+1. Jalankan dashboard dan API melalui HTTPS, lalu set `IGNITIFY_SECURE_COOKIES=true`.
+2. Set `IGNITIFY_TRUSTED_ORIGINS` ke URL dashboard aktual, tanpa wildcard.
+3. Gunakan `IGNITIFY_JWT_SECRET` dan `IGNITIFY_SECRETS_AGE_IDENTITY` yang dikelola secara aman; backup keduanya bersama database karena data terenkripsi tidak dapat dibuka tanpa identity yang sama.
+4. Batasi kepemilikan dan permission `IGNITIFY_DATA_DIR`, database, checkout build, dan Compose root.
+5. Jangan expose Docker socket langsung ke jaringan. Berikan least privilege pada proses/operator yang mengaksesnya.
+6. Pisahkan build host bila menerima repository yang tidak sepenuhnya tepercaya, dan tetapkan resource quota Docker.
+7. Arahkan DNS dan TLS melalui ingress; jangan mengekspos port API backend langsung ke internet.
+8. Batasi akun admin dan audit activity deployment/provider secara rutin.
+
+## Batas yang perlu dipahami
+
+- Source Git menggunakan credential hanya untuk checkout sementara. Credential tidak boleh menjadi variable service, snapshot deployment, image build, atau command build.
+- Executor build tidak mendukung GitHub App credential saat ini. Jangan menyimpulkan bahwa provider GitHub App otomatis dapat melakukan checkout source build.
+- Build log belum menjadi stream API append-only. Jangan membangun workflow operasional yang menganggap log build tersedia dari endpoint deployment.
+- Tidak ada model keamanan yang dapat menjadikan Docker aman untuk code build yang benar-benar bermusuhan tanpa isolasi host, quota, dan policy tambahan.
+
+## Respons insiden
+
+Jika JWT secret atau identity age diduga bocor, anggap session aktif dan data terenkripsi terpengaruh. Rotasi secret, cabut session/refresh family bila diperlukan, nilai dampak backup data, dan audit provider serta activity log. Rotasi identity age membutuhkan rencana re-enkripsi data; mengganti identity tanpa migrasi membuat nilai lama tidak dapat didekripsi.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# Ignitify
+
+Ignitify is a self-hosted control plane for running applications, Compose services, and OCI images on your own infrastructure. This documentation describes the current implementation, not the roadmap.
+
+## Start here
+
+- [Getting started locally](/guide/getting-started) to set up the backend and dashboard.
+- [Architecture](/concepts/architecture) to understand each crate boundary and the data flow.
+- [Deployment lifecycle](/concepts/deployment-lifecycle) to understand services, environments, domains, and workers.
+- [API reference](/reference/api) for every registered HTTP route.
+- [Ignitify Templates](https://github.com/xFlawlessDev/ignitify-templates) for the public template catalog and contribution workflow.
+
+## Current capabilities
+
+| Area       | Capabilities                                                                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Access     | One-time admin bootstrap, login, JWT access tokens, and cookie-based refresh tokens.                                                         |
+| Workspace  | SQLite projects, owner/editor/viewer roles, services, environments, activity, and dashboard.                                                 |
+| Deployment | OCI images pinned to digests, validated Compose, Git sources for applications or Compose, a queue worker, rollback, events, and log streams. |
+| Operations | Runtime status, host/container metrics, Docker admin inventory and actions, and admin host/container terminals.                              |
+| Ingress    | Traefik operator, service domains, ACME TLS, and the `ignitify-proxy` network.                                                               |
+
+## Repository sections
+
+```text
+ignitify/       Rust control plane and Vue administrator dashboard
+```
+
+The administrator dashboard lives in `ignitify/frontend`.
+
+## Operational status
+
+The backend listens on `127.0.0.1:5656` by default; the development dashboard runs on port `6565`. Public exposure should go through a deliberately configured reverse proxy or ingress operator. Read [configuration](/operations/configuration) and [security](/reference/security) before running on a publicly reachable host.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,0 +1,42 @@
+# Configuration
+
+Store backend overrides in `ignitify/.env`, starting from `.env.example`. The file contains secrets and must not be committed to Git.
+
+## Basic backend
+
+| Variable                        | Default                                       | Purpose                                                     |
+| ------------------------------- | --------------------------------------------- | ----------------------------------------------------------- |
+| `IGNITIFY_DATABASE_URL`         | `sqlite:data/ignitify.db`                     | SQLite database location.                                   |
+| `IGNITIFY_DATA_DIR`             | `data`                                        | Runtime secrets and local data directory.                   |
+| `IGNITIFY_JWT_SECRET`           | generated on first start                      | JWT secret with at least 32 characters when explicitly set. |
+| `IGNITIFY_SECRETS_AGE_IDENTITY` | generated on first start                      | Age identity for encrypting configuration/environment.      |
+| `IGNITIFY_SECURE_COOKIES`       | `false`                                       | Set `true` when the dashboard is accessed over HTTPS.       |
+| `IGNITIFY_TRUSTED_ORIGINS`      | `http://localhost:6565,http://127.0.0.1:6565` | Comma-separated dashboard origins.                          |
+
+The backend binds to `127.0.0.1:5656` in the current implementation. Use a local reverse proxy or deliberately change the implementation when connections from another interface are required. Do not simply open the firewall and assume the service is available from another network.
+
+## Docker and Compose
+
+| Variable                        | Purpose                                                           |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `IGNITIFY_DOCKER_HOST`          | Override the Docker endpoint, for example `tcp://127.0.0.1:2375`. |
+| `IGNITIFY_DOCKER_BIN`           | Docker executable path when it is not on `PATH`.                  |
+| `IGNITIFY_COMPOSE_ROOT`         | Root for Compose material managed by the runtime.                 |
+| `IGNITIFY_AUTO_START_INGRESS`   | Set `false` when Traefik is managed by an external operator.      |
+| `IGNITIFY_TRAEFIK_COMPOSE_FILE` | Traefik operator Compose path.                                    |
+| `IGNITIFY_ACME_EMAIL`           | ACME contact for production certificates.                         |
+
+When using a Docker socket, restrict access by the Ignitify process. Docker grants extensive host capabilities; treat the dashboard and control plane API as administrative surfaces.
+
+## Git source builds
+
+| Variable                           | Purpose                                        |
+| ---------------------------------- | ---------------------------------------------- |
+| `IGNITIFY_SOURCE_BUILD_ROOT`       | Temporary source checkout directory.           |
+| `IGNITIFY_GIT_BIN`                 | Git path.                                      |
+| `IGNITIFY_RAILPACK_BIN`            | Railpack binary path.                          |
+| `IGNITIFY_STATIC_BUILD_IMAGE`      | Digest-pinned Node builder for static builds.  |
+| `IGNITIFY_STATIC_RUNTIME_IMAGE`    | Digest-pinned Caddy runtime for static output. |
+| `IGNITIFY_RAILPACK_FRONTEND_IMAGE` | Railpack frontend image pinned to a digest.    |
+
+Builder/runtime defaults are bundled. Override them only when replacing a reviewed release. The build host must provide Git and Docker Buildx; production should use a dedicated build host and Docker quotas.

--- a/docs/operations/ingress-and-domains.md
+++ b/docs/operations/ingress-and-domains.md
@@ -1,0 +1,41 @@
+# Ingress and domains
+
+Ignitify uses a Traefik operator to expose services with domains. The operator stack lives in `ignitify/infra/traefik/` and can be started automatically by the backend unless `IGNITIFY_AUTO_START_INGRESS=false`.
+
+## Production prerequisites
+
+1. The host must run Docker and be able to create the `ignitify-proxy` network.
+2. Each domain's DNS A/AAAA record must point to the ingress host.
+3. HTTP/HTTPS ports must be available at the host perimeter for Traefik.
+4. `IGNITIFY_ACME_EMAIL` must be a real contact address before requesting certificates.
+5. Keep the Traefik dashboard disabled; do not enable it without suitable authentication and network policy.
+
+For a manually managed operator, run from the `ignitify` root:
+
+```bash
+docker compose --env-file infra/traefik/.env -f infra/traefik/compose.yaml up -d
+```
+
+After the backend starts, `GET /api/v1/runtime/status` should report `"ingress":"ready"` for an authenticated user.
+
+## Add a domain
+
+1. Create or select a service with an `internal_port`.
+2. Add a complete hostname such as `app.example.com` through the dashboard or `POST /api/v1/services/{service_id}/domains`.
+3. Ensure DNS points to the host before expecting ACME TLS.
+4. Redeploy the service if needed so the worker applies the route.
+5. Monitor the domain through the service domain list and deployment events.
+
+Hostnames must be lower-case ASCII, contain at least one dot, and not be a wildcard, IP, `localhost`, or public suffix such as `co.uk`.
+
+## Troubleshooting
+
+| Symptom                           | Check                                                                            |
+| --------------------------------- | -------------------------------------------------------------------------------- |
+| Ingress unavailable               | Check Docker, the Traefik stack, Compose configuration, and `ingress` status.    |
+| Domain remains pending            | Check deployment/events, the domain name, DNS, and the service's internal port.  |
+| Domain failed                     | Check deployment events; route reconciliation failures mark the domain `failed`. |
+| TLS is not issued                 | Check public DNS, ports 80/443, and `IGNITIFY_ACME_EMAIL`.                       |
+| Service is not found by the proxy | Ensure the service is Ignitify-managed and connected to `ignitify-proxy`.        |
+
+Do not add manual Traefik labels to Ignitify-managed containers. The worker owns those labels and may overwrite manual configuration during the next reconciliation.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,116 @@
+# Control plane API
+
+Local base URL: `http://127.0.0.1:5656`. All control plane routes are under `/api/v1`, except `GET /health`.
+
+## Conventions
+
+- Requests and responses use JSON except for multipart uploads, SSE, and the terminal WebSocket.
+- Protected routes require `Authorization: Bearer <access-token>`.
+- State-changing requests also require `X-Ignitify-Request: 1` and an `Origin` listed in `IGNITIFY_TRUSTED_ORIGINS`.
+- Error responses do not expose database, token, or runtime details. Statuses `400`, `401`, `403`, `404`, `409`, and `500` represent the general failure classes.
+- Resource identifiers are UUIDs. Use an idempotency key when creating a deployment.
+
+## Authentication
+
+| Method | Path                     | Auth   | Description                                            |
+| ------ | ------------------------ | ------ | ------------------------------------------------------ |
+| `GET`  | `/health`                | None   | Basic process probe.                                   |
+| `GET`  | `/api/v1/auth/bootstrap` | None   | Check whether the first admin is required.             |
+| `POST` | `/api/v1/auth/bootstrap` | None   | Create the first admin; only once.                     |
+| `POST` | `/api/v1/auth/login`     | None   | Create a session and refresh cookie.                   |
+| `POST` | `/api/v1/auth/refresh`   | Cookie | Rotate the refresh token and issue a new access token. |
+| `POST` | `/api/v1/auth/logout`    | Cookie | Revoke the refresh session and remove the cookie.      |
+| `GET`  | `/api/v1/auth/me`        | Yes    | Return the current user.                               |
+
+Bootstrap/login bodies use `{ "username": "...", "password": "..." }`. The session response contains `access_token`, `token_type`, `expires_at`, and `user`; the refresh cookie is sent with `Set-Cookie`.
+
+## Dashboard and providers
+
+| Method            | Path                                           | Description                                             |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------- |
+| `GET`             | `/api/v1/dashboard`                            | Project, service, and deployment summary for the actor. |
+| `GET`, `POST`     | `/api/v1/providers`                            | List or create a source provider.                       |
+| `POST`            | `/api/v1/providers/github/manifest`            | Start the GitHub App manifest flow.                     |
+| `GET`             | `/api/v1/providers/github/manifest/callback`   | GitHub manifest callback.                               |
+| `PATCH`, `DELETE` | `/api/v1/providers/{provider_id}`              | Update or delete a provider.                            |
+| `POST`            | `/api/v1/providers/{provider_id}/test`         | Test a provider connection.                             |
+| `GET`             | `/api/v1/providers/{provider_id}/repositories` | List accessible repositories.                           |
+| `GET`             | `/api/v1/providers/{provider_id}/branches`     | List branches for a provider repository.                |
+
+Provider credentials are encrypted by the backend. The GitHub App manifest flow and provider discovery do not mean every provider credential can be used by the build executor; the Git executor does not currently support GitHub App credentials.
+
+## Runtime and terminal
+
+| Method   | Path                                                 | Access | Description                                                   |
+| -------- | ---------------------------------------------------- | ------ | ------------------------------------------------------------- |
+| `GET`    | `/api/v1/runtime/status`                             | User   | Database/runtime/worker/ingress readiness and metric summary. |
+| `GET`    | `/api/v1/runtime/metrics`                            | User   | CPU, memory, disk, network, and container metrics.            |
+| `GET`    | `/api/v1/runtime/containers`                         | User   | Container inventory when the runtime is available.            |
+| `GET`    | `/api/v1/runtime/containers/{container_id}/details`  | Admin  | Configuration, mounts, network, and label details.            |
+| `GET`    | `/api/v1/runtime/containers/{container_id}/logs`     | Admin  | Container logs.                                               |
+| `POST`   | `/api/v1/runtime/containers/{container_id}/upload`   | Admin  | Multipart upload, maximum 8 MiB.                              |
+| `DELETE` | `/api/v1/runtime/containers/{container_id}`          | Admin  | Delete a container.                                           |
+| `GET`    | `/api/v1/terminal`                                   | Admin  | Upgrade to the host terminal WebSocket.                       |
+| `GET`    | `/api/v1/runtime/containers/{container_id}/terminal` | Admin  | Upgrade to the container terminal WebSocket.                  |
+
+Uploads accept the multipart `file` field and an optional `destination` (default `/tmp`). The terminal authenticates and validates the WebSocket origin; use the dashboard client as the protocol reference.
+
+## Projects, environments, and services
+
+| Method                   | Path                                        | Description                                      |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------ |
+| `GET`, `POST`            | `/api/v1/projects`                          | List accessible projects or create a project.    |
+| `GET`, `PATCH`           | `/api/v1/projects/{project_id}`             | Read or update a project.                        |
+| `GET`, `PUT`             | `/api/v1/projects/{project_id}/environment` | Read or replace the project default environment. |
+| `GET`                    | `/api/v1/projects/{project_id}/deployments` | Deployments for every service in the project.    |
+| `GET`                    | `/api/v1/projects/{project_id}/activity`    | Project activity.                                |
+| `GET`, `POST`            | `/api/v1/projects/{project_id}/services`    | List or create a service.                        |
+| `GET`, `PATCH`, `DELETE` | `/api/v1/services/{service_id}`             | Read, update, or delete a service.               |
+| `GET`, `POST`            | `/api/v1/services/{service_id}/domains`     | List or add a domain.                            |
+| `DELETE`                 | `/api/v1/domains/{domain_id}`               | Delete a domain with confirmation.               |
+
+Example image service request:
+
+```json
+{
+  "name": "web",
+  "kind": "image",
+  "image_reference": "nginx@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "internal_port": 8080,
+  "healthcheck": ["/bin/sh", "-c", "wget -qO- http://localhost:8080/health"],
+  "variables": [
+    { "key": "LOG_LEVEL", "value": "info", "is_secret": false },
+    { "key": "DATABASE_URL", "value": "secret", "is_secret": true }
+  ]
+}
+```
+
+For a Compose service, use `kind: "compose"`, `compose_yaml`, `exposed_service`, `internal_port`, and `variables`. `source_config` can be added for a template, Git Compose, or application source. Secret values are not returned as plaintext.
+
+Project environments use this shape. To keep an existing secret, send `value: null` with `is_secret: true`; a new value is required for non-secret variables.
+
+```json
+{
+  "variables": [
+    { "key": "REGION", "value": "id", "is_secret": false },
+    { "key": "API_KEY", "value": null, "is_secret": true }
+  ]
+}
+```
+
+## Deployments and streams
+
+| Method        | Path                                           | Description                                      |
+| ------------- | ---------------------------------------------- | ------------------------------------------------ |
+| `GET`, `POST` | `/api/v1/services/{service_id}/deployments`    | List service deployments or submit a deployment. |
+| `POST`        | `/api/v1/services/{service_id}/stop`           | Request a service stop.                          |
+| `GET`         | `/api/v1/deployments/{deployment_id}`          | Deployment details.                              |
+| `POST`        | `/api/v1/deployments/{deployment_id}/rollback` | Submit a rollback from a deployment snapshot.    |
+| `GET`         | `/api/v1/deployments/{deployment_id}/events`   | Deployment lifecycle SSE events.                 |
+| `GET`         | `/api/v1/deployments/{deployment_id}/logs`     | SSE log lines.                                   |
+
+Deployment submission requires an idempotency key header according to the client contract. To resume SSE, send `Last-Event-ID` or the `after=<sequence>` query parameter. Streams send a `snapshot` event when the cursor is older than the retained data, a heartbeat about every 15 seconds, and `log` events on the log stream.
+
+## Contract sources
+
+The routes above come from `ignitify/crates/ignitify-api/src/routes.rs`. Response DTOs and specific validation live in `handlers/` and `ignitify-domain`. When changing a contract, update the route, typed dashboard client, tests, and this page in one change.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,0 +1,40 @@
+# Security
+
+Ignitify can access Docker, source builds, ingress, and terminals. Treat it as an administrative system, not an ordinary public application.
+
+## Applied controls
+
+| Area                 | Control                                                                                               |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| Passwords            | Argon2 hashing; plaintext passwords are not persisted.                                                |
+| Access sessions      | 15-minute JWTs; the dashboard keeps access tokens in memory.                                          |
+| Refresh sessions     | HttpOnly cookie, hashed stored token, rotation, and reuse detection that revokes the family.          |
+| CSRF/origin          | State-changing endpoints check `X-Ignitify-Request` and trusted origin.                               |
+| Secret configuration | Project/service environments and provider credentials are encrypted with age.                         |
+| Secret output        | Secret values are masked in read models; the worker redacts logs that may contain snapshot values.    |
+| Authorization        | Project roles are checked by repositories; Docker and terminal actions require admin.                 |
+| Runtime images       | Service images must use a SHA-256 digest.                                                             |
+| Compose              | Policy rejects unsupported or risky configuration before submission.                                  |
+| Ingress              | Traefik only sees containers labeled `com.ignitify.managed=true`; the operator dashboard is disabled. |
+
+## Production checklist
+
+1. Run the dashboard and API over HTTPS, then set `IGNITIFY_SECURE_COOKIES=true`.
+2. Set `IGNITIFY_TRUSTED_ORIGINS` to the actual dashboard URL, without wildcards.
+3. Use securely managed `IGNITIFY_JWT_SECRET` and `IGNITIFY_SECRETS_AGE_IDENTITY`; back up both with the database because encrypted data cannot be opened without the same identity.
+4. Restrict ownership and permissions for `IGNITIFY_DATA_DIR`, the database, the build checkout, and the Compose root.
+5. Never expose the Docker socket directly to the network. Give least privilege to the process/operator accessing it.
+6. Isolate the build host when accepting repositories that are not fully trusted, and set Docker resource quotas.
+7. Route DNS and TLS through ingress; do not expose the backend API port directly to the internet.
+8. Limit administrator accounts and audit deployment/provider activity regularly.
+
+## Important limitations
+
+- Git source uses credentials only for temporary checkout. Credentials must not become service variables, deployment snapshots, image build inputs, or build commands.
+- The build executor does not currently support GitHub App credentials. A GitHub App provider does not automatically make source checkout available.
+- Build logs are not yet an append-only API stream. Do not build an operational workflow that assumes build logs are available from deployment endpoints.
+- No security model can make Docker safe for truly hostile build code without host isolation, quotas, and additional policy.
+
+## Incident response
+
+If a JWT secret or age identity may have leaked, assume active sessions and encrypted data are affected. Rotate the secret, revoke sessions/refresh families as needed, assess backup impact, and audit providers and activity logs. Rotating the age identity requires a data re-encryption plan; replacing the identity without migration makes old values undecryptable.


### PR DESCRIPTION
## Summary\n- add the reviewed English and Indonesian documentation content\n- define docs/ as the portable source consumed by the separate marketing-site VitePress app\n- keep VitePress configuration, navigation, build, and deployment outside the control-plane repository\n\n## Verification\n- git diff --check\n- stale local VitePress instructions scan passed\n- documentation content scan found no real credentials