### PR TITLE
feat: retain uptime monitoring history

### DIFF
--- a/crates/ignitify-api/src/handlers/uptime_monitors.rs
+++ b/crates/ignitify-api/src/handlers/uptime_monitors.rs
@@ -2,10 +2,13 @@ use std::net::IpAddr;
 
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
 };
-use ignitify_db::{NewUptimeMonitor, UptimeMonitorRecord, UptimeMonitorUpdate};
+use ignitify_db::{
+    NewUptimeMonitor, UPTIME_HISTORY_RETENTION_DAYS, UptimeMonitorHistory, UptimeMonitorRecord,
+    UptimeMonitorUpdate,
+};
 use serde::{Deserialize, Serialize};
 use url::{Host, Url};
 
@@ -19,6 +22,8 @@ const MAX_NAME_LENGTH: usize = 120;
 const MAX_TARGET_LENGTH: usize = 2_048;
 const MIN_INTERVAL_SECONDS: u32 = 30;
 const MAX_INTERVAL_SECONDS: u32 = 86_400;
+const DEFAULT_HISTORY_WINDOW_HOURS: u32 = 24;
+const MAX_HISTORY_RESPONSE_ROWS: u32 = 500;
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -47,6 +52,40 @@ pub(crate) struct UptimeMonitorResponse {
     updated_at: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct UptimeHistoryQuery {
+    hours: Option<u32>,
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct UptimeMonitorHistoryResponse {
+    monitor_id: String,
+    retention_days: i64,
+    checks: Vec<UptimeCheckResponse>,
+    summary: UptimeAvailabilityResponse,
+}
+
+#[derive(Debug, Serialize)]
+struct UptimeCheckResponse {
+    status: String,
+    latency_ms: Option<i64>,
+    error: Option<String>,
+    checked_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct UptimeAvailabilityResponse {
+    window_hours: u32,
+    total_checks: i64,
+    successful_checks: i64,
+    failed_checks: i64,
+    availability_percentage: Option<f64>,
+    error_budget_percentage: Option<f64>,
+    budget_consumed_percentage: Option<f64>,
+    status: String,
+}
+
 impl From<UptimeMonitorRecord> for UptimeMonitorResponse {
     fn from(record: UptimeMonitorRecord) -> Self {
         Self {
@@ -63,6 +102,35 @@ impl From<UptimeMonitorRecord> for UptimeMonitorResponse {
             last_error: record.last_error,
             created_at: record.created_at,
             updated_at: record.updated_at,
+        }
+    }
+}
+
+impl UptimeMonitorHistoryResponse {
+    fn from_history(monitor_id: String, history: UptimeMonitorHistory) -> Self {
+        Self {
+            monitor_id,
+            retention_days: UPTIME_HISTORY_RETENTION_DAYS,
+            checks: history
+                .checks
+                .into_iter()
+                .map(|check| UptimeCheckResponse {
+                    status: check.status,
+                    latency_ms: check.latency_ms,
+                    error: check.error,
+                    checked_at: check.checked_at,
+                })
+                .collect(),
+            summary: UptimeAvailabilityResponse {
+                window_hours: history.summary.window_hours,
+                total_checks: history.summary.total_checks,
+                successful_checks: history.summary.successful_checks,
+                failed_checks: history.summary.failed_checks,
+                availability_percentage: history.summary.availability_percentage,
+                error_budget_percentage: history.summary.error_budget_percentage,
+                budget_consumed_percentage: history.summary.budget_consumed_percentage,
+                status: history.summary.status,
+            },
         }
     }
 }
@@ -104,6 +172,32 @@ pub(crate) async fn create(
         })
         .await?;
     Ok((StatusCode::CREATED, Json(record.into())))
+}
+
+pub(crate) async fn history(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(monitor_id): Path<String>,
+    Query(query): Query<UptimeHistoryQuery>,
+) -> Result<Json<UptimeMonitorHistoryResponse>, ApiError> {
+    let actor = require_actor(&state, &headers).await?;
+    let hours = query.hours.unwrap_or(DEFAULT_HISTORY_WINDOW_HOURS);
+    if hours == 0 || hours > (UPTIME_HISTORY_RETENTION_DAYS * 24) as u32 {
+        return Err(ApiError::BadRequest("monitor history window is invalid"));
+    }
+    let limit = query.limit.unwrap_or(100);
+    if limit == 0 || limit > MAX_HISTORY_RESPONSE_ROWS {
+        return Err(ApiError::BadRequest("monitor history limit is invalid"));
+    }
+    let history = state
+        .database
+        .uptime_monitors()
+        .history_for_user(&actor.id, &monitor_id, hours, limit)
+        .await?
+        .ok_or(ApiError::NotFound)?;
+    Ok(Json(UptimeMonitorHistoryResponse::from_history(
+        monitor_id, history,
+    )))
 }
 
 pub(crate) async fn update(

--- a/crates/ignitify-api/src/openapi.rs
+++ b/crates/ignitify-api/src/openapi.rs
@@ -396,6 +396,12 @@ protected_mutation_param!(
     "Monitoring",
     "monitor_id"
 );
+protected_get_param!(
+    uptime_monitor_history_doc,
+    "/api/v1/uptime-monitors/{monitor_id}/history",
+    "Monitoring",
+    "monitor_id"
+);
 
 protected_get!(projects_doc, "/api/v1/projects", "Projects");
 protected_mutation!(create_project_doc, post, "/api/v1/projects", "Projects");
@@ -672,6 +678,7 @@ protected_get!(terminal_doc, "/api/v1/terminal", "Terminal");
         create_uptime_monitor_doc,
         remove_uptime_monitor_doc,
         update_uptime_monitor_doc,
+        uptime_monitor_history_doc,
         projects_doc,
         create_project_doc,
         get_project_doc,

--- a/crates/ignitify-api/src/routes.rs
+++ b/crates/ignitify-api/src/routes.rs
@@ -201,6 +201,10 @@ pub(crate) fn router(state: AppState) -> Router {
             axum::routing::delete(handlers::uptime_monitors::remove)
                 .patch(handlers::uptime_monitors::update),
         )
+        .route(
+            "/api/v1/uptime-monitors/{monitor_id}/history",
+            get(handlers::uptime_monitors::history),
+        )
         .route("/api/v1/terminal", get(handlers::terminal::open))
         .route(
             "/api/v1/projects",

--- a/crates/ignitify-api/src/tests.rs
+++ b/crates/ignitify-api/src/tests.rs
@@ -204,6 +204,34 @@ async fn uptime_monitor_api_validates_and_persists_custom_endpoints() {
     let listed_json: serde_json::Value = serde_json::from_slice(&listed_body).unwrap();
     assert_eq!(listed_json.as_array().unwrap().len(), 1);
 
+    let history = app
+        .clone()
+        .oneshot(request(
+            "GET",
+            &format!("/api/v1/uptime-monitors/{monitor_id}/history?hours=24&limit=100"),
+            Some(&token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(history.status(), StatusCode::OK);
+    let history_body = history.into_body().collect().await.unwrap().to_bytes();
+    let history_json: serde_json::Value = serde_json::from_slice(&history_body).unwrap();
+    assert_eq!(history_json["retention_days"], 30);
+    assert_eq!(history_json["summary"]["status"], "insufficient_data");
+
+    let invalid_history = app
+        .clone()
+        .oneshot(request(
+            "GET",
+            &format!("/api/v1/uptime-monitors/{monitor_id}/history?hours=0"),
+            Some(&token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(invalid_history.status(), StatusCode::BAD_REQUEST);
+
     let removed = app
         .oneshot(request(
             "DELETE",

--- a/crates/ignitify-db/migrations/0038_uptime_check_history.sql
+++ b/crates/ignitify-db/migrations/0038_uptime_check_history.sql
@@ -1,0 +1,11 @@
+CREATE TABLE uptime_monitor_checks (
+    id TEXT PRIMARY KEY,
+    monitor_id TEXT NOT NULL REFERENCES uptime_monitors(id) ON DELETE CASCADE,
+    status TEXT NOT NULL CHECK (status IN ('up', 'down')),
+    latency_ms INTEGER,
+    error TEXT,
+    checked_at TEXT NOT NULL
+);
+
+CREATE INDEX uptime_monitor_checks_monitor_checked_idx
+    ON uptime_monitor_checks(monitor_id, checked_at DESC);

--- a/crates/ignitify-db/src/lib.rs
+++ b/crates/ignitify-db/src/lib.rs
@@ -34,8 +34,10 @@ pub use repositories::{
     RemoteServerAgentsRepository, RemoteServerConnection, RemoteServerRecord, RemoteServerUpdate,
     RemoteServersRepository, RetrySchedule, SequenceCursor, ServerCertificateRecord,
     ServerSettingsRecord, ServerSettingsRepository, ServerSettingsUpdate, ServiceActor,
-    ServiceMutationOutcome, ServiceVariableRecord, ServicesRepository, UptimeCheckUpdate,
-    UptimeMonitorRecord, UptimeMonitorUpdate, UptimeMonitorsRepository, UsersRepository,
+    ServiceMutationOutcome, ServiceVariableRecord, ServicesRepository, UPTIME_HISTORY_MAX_ROWS,
+    UPTIME_HISTORY_RETENTION_DAYS, UptimeAvailabilitySummary, UptimeCheckRecord, UptimeCheckUpdate,
+    UptimeMonitorHistory, UptimeMonitorRecord, UptimeMonitorUpdate, UptimeMonitorsRepository,
+    UsersRepository,
 };
 
 #[cfg(test)]

--- a/crates/ignitify-db/src/repositories/mod.rs
+++ b/crates/ignitify-db/src/repositories/mod.rs
@@ -82,7 +82,8 @@ pub use settings::{
     ServerSettingsUpdate,
 };
 pub use uptime_monitors::{
-    NewUptimeMonitor, UptimeCheckUpdate, UptimeMonitorRecord, UptimeMonitorUpdate,
-    UptimeMonitorsRepository,
+    NewUptimeMonitor, UPTIME_HISTORY_MAX_ROWS, UPTIME_HISTORY_RETENTION_DAYS,
+    UptimeAvailabilitySummary, UptimeCheckRecord, UptimeCheckUpdate, UptimeMonitorHistory,
+    UptimeMonitorRecord, UptimeMonitorUpdate, UptimeMonitorsRepository,
 };
 pub use users::{AuditContext, AuditOutcome, UsersRepository};

--- a/crates/ignitify-db/src/repositories/uptime_monitors.rs
+++ b/crates/ignitify-db/src/repositories/uptime_monitors.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use serde_json::Value;
 use sqlx::{FromRow, SqlitePool};
 use uuid::Uuid;
@@ -6,6 +6,10 @@ use uuid::Uuid;
 use crate::{DatabaseError, Result};
 
 const HISTORY_LENGTH: usize = 30;
+pub const UPTIME_HISTORY_RETENTION_DAYS: i64 = 30;
+pub const UPTIME_HISTORY_MAX_ROWS: i64 = 1_000;
+pub const UPTIME_ERROR_BUDGET_TARGET_PERCENTAGE: f64 = 99.0;
+pub const UPTIME_MIN_CHECKS_FOR_ALERT: i64 = 3;
 
 #[derive(Debug, Clone)]
 pub struct UptimeMonitorRecord {
@@ -50,6 +54,32 @@ pub struct UptimeCheckUpdate {
     pub latency_ms: Option<u64>,
     pub last_error: Option<String>,
     pub checked_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UptimeCheckRecord {
+    pub status: String,
+    pub latency_ms: Option<i64>,
+    pub error: Option<String>,
+    pub checked_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UptimeAvailabilitySummary {
+    pub window_hours: u32,
+    pub total_checks: i64,
+    pub successful_checks: i64,
+    pub failed_checks: i64,
+    pub availability_percentage: Option<f64>,
+    pub error_budget_percentage: Option<f64>,
+    pub budget_consumed_percentage: Option<f64>,
+    pub status: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct UptimeMonitorHistory {
+    pub checks: Vec<UptimeCheckRecord>,
+    pub summary: UptimeAvailabilitySummary,
 }
 
 #[derive(Debug, Clone)]
@@ -176,15 +206,17 @@ impl UptimeMonitorsRepository {
         expected_updated_at: &str,
         update: UptimeCheckUpdate,
     ) -> Result<bool> {
+        let mut transaction = self.pool.begin().await?;
         let existing = sqlx::query_as::<_, HistoryRow>(
             "SELECT history_json FROM uptime_monitors
              WHERE id = ? AND enabled = 1 AND updated_at = ?",
         )
         .bind(id)
         .bind(expected_updated_at)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *transaction)
         .await?;
         let Some(existing) = existing else {
+            transaction.rollback().await?;
             return Ok(false);
         };
         let mut history = parse_history(&existing.history_json)?;
@@ -213,9 +245,136 @@ impl UptimeMonitorsRepository {
         .bind(&update.checked_at)
         .bind(id)
         .bind(expected_updated_at)
-        .execute(&self.pool)
+        .execute(&mut *transaction)
         .await?;
-        Ok(result.rows_affected() == 1)
+        if result.rows_affected() != 1 {
+            transaction.rollback().await?;
+            return Ok(false);
+        }
+        sqlx::query(
+            "INSERT INTO uptime_monitor_checks
+             (id, monitor_id, status, latency_ms, error, checked_at)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(id)
+        .bind(&update.status)
+        .bind(
+            update
+                .latency_ms
+                .map(|value| i64::try_from(value).unwrap_or(i64::MAX)),
+        )
+        .bind(&update.last_error)
+        .bind(&update.checked_at)
+        .execute(&mut *transaction)
+        .await?;
+        prune_check_history(&mut transaction, id).await?;
+        transaction.commit().await?;
+        Ok(true)
+    }
+
+    pub async fn history_for_user(
+        &self,
+        user_id: &str,
+        id: &str,
+        window_hours: u32,
+        limit: u32,
+    ) -> Result<Option<UptimeMonitorHistory>> {
+        let exists = sqlx::query_scalar::<_, i64>(
+            "SELECT 1 FROM uptime_monitors WHERE id = ? AND user_id = ?",
+        )
+        .bind(id)
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        if exists.is_none() {
+            return Ok(None);
+        }
+        let window_hours = window_hours.clamp(1, (UPTIME_HISTORY_RETENTION_DAYS * 24) as u32);
+        let limit = i64::from(limit.clamp(1, UPTIME_HISTORY_MAX_ROWS as u32));
+        let since = (Utc::now() - Duration::hours(i64::from(window_hours))).to_rfc3339();
+        let summary = sqlx::query_as::<_, UptimeHistorySummaryRow>(
+            "SELECT COUNT(*) AS total_checks,
+                    COALESCE(SUM(CASE WHEN status = 'up' THEN 1 ELSE 0 END), 0) AS successful_checks,
+                    COALESCE(SUM(CASE WHEN status = 'down' THEN 1 ELSE 0 END), 0) AS failed_checks
+             FROM uptime_monitor_checks
+             WHERE monitor_id = ? AND julianday(checked_at) >= julianday(?)",
+        )
+        .bind(id)
+        .bind(&since)
+        .fetch_one(&self.pool)
+        .await?;
+        let rows = sqlx::query_as::<_, UptimeCheckRow>(
+            "SELECT status, latency_ms, error, checked_at
+             FROM uptime_monitor_checks
+             WHERE monitor_id = ? AND julianday(checked_at) >= julianday(?)
+             ORDER BY checked_at DESC
+             LIMIT ?",
+        )
+        .bind(id)
+        .bind(since)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut checks = rows
+            .into_iter()
+            .map(UptimeCheckRow::into_record)
+            .collect::<Vec<_>>();
+        checks.reverse();
+        let total_checks = summary.total_checks;
+        let successful_checks = summary.successful_checks;
+        let failed_checks = summary.failed_checks;
+        let availability_percentage =
+            (total_checks > 0).then(|| (successful_checks as f64 / total_checks as f64) * 100.0);
+        let error_budget_percentage = availability_percentage
+            .map(|availability| (availability - UPTIME_ERROR_BUDGET_TARGET_PERCENTAGE).max(0.0));
+        let budget_consumed_percentage = (total_checks > 0).then(|| {
+            (failed_checks as f64 / total_checks as f64)
+                / (100.0 - UPTIME_ERROR_BUDGET_TARGET_PERCENTAGE)
+                * 100.0
+        });
+        let status = if total_checks < UPTIME_MIN_CHECKS_FOR_ALERT {
+            "insufficient_data"
+        } else if availability_percentage
+            .is_some_and(|value| value < UPTIME_ERROR_BUDGET_TARGET_PERCENTAGE)
+        {
+            "exhausted"
+        } else if budget_consumed_percentage.is_some_and(|value| value >= 80.0) {
+            "warning"
+        } else {
+            "healthy"
+        };
+        Ok(Some(UptimeMonitorHistory {
+            checks,
+            summary: UptimeAvailabilitySummary {
+                window_hours,
+                total_checks,
+                successful_checks,
+                failed_checks,
+                availability_percentage,
+                error_budget_percentage,
+                budget_consumed_percentage,
+                status: status.to_owned(),
+            },
+        }))
+    }
+
+    pub async fn budget_breached_count(&self) -> Result<i64> {
+        Ok(sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM (
+                 SELECT monitor_id
+                 FROM uptime_monitor_checks
+                 WHERE julianday(checked_at) >= julianday('now', '-24 hours')
+                 GROUP BY monitor_id
+                 HAVING COUNT(*) >= ?
+                    AND SUM(CASE WHEN status = 'down' THEN 1 ELSE 0 END) * 100.0 / COUNT(*)
+                        > (100.0 - ?)
+             )",
+        )
+        .bind(UPTIME_MIN_CHECKS_FOR_ALERT)
+        .bind(UPTIME_ERROR_BUDGET_TARGET_PERCENTAGE)
+        .fetch_one(&self.pool)
+        .await?)
     }
 
     async fn get_for_user(&self, user_id: &str, id: &str) -> Result<Option<UptimeMonitorRecord>> {
@@ -303,4 +462,61 @@ impl UptimeMonitorRow {
 #[derive(Debug, FromRow)]
 struct HistoryRow {
     history_json: String,
+}
+
+#[derive(Debug, FromRow)]
+struct UptimeCheckRow {
+    status: String,
+    latency_ms: Option<i64>,
+    error: Option<String>,
+    checked_at: String,
+}
+
+#[derive(Debug, FromRow)]
+struct UptimeHistorySummaryRow {
+    total_checks: i64,
+    successful_checks: i64,
+    failed_checks: i64,
+}
+
+impl UptimeCheckRow {
+    fn into_record(self) -> UptimeCheckRecord {
+        UptimeCheckRecord {
+            status: self.status,
+            latency_ms: self.latency_ms,
+            error: self.error,
+            checked_at: self.checked_at,
+        }
+    }
+}
+
+async fn prune_check_history(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    monitor_id: &str,
+) -> Result<()> {
+    let cutoff = (Utc::now() - Duration::days(UPTIME_HISTORY_RETENTION_DAYS)).to_rfc3339();
+    sqlx::query(
+        "DELETE FROM uptime_monitor_checks
+         WHERE monitor_id = ? AND julianday(checked_at) < julianday(?)",
+    )
+    .bind(monitor_id)
+    .bind(cutoff)
+    .execute(&mut **transaction)
+    .await?;
+    sqlx::query(
+        "DELETE FROM uptime_monitor_checks
+         WHERE monitor_id = ?
+           AND id NOT IN (
+               SELECT id FROM uptime_monitor_checks
+               WHERE monitor_id = ?
+               ORDER BY checked_at DESC
+               LIMIT ?
+           )",
+    )
+    .bind(monitor_id)
+    .bind(monitor_id)
+    .bind(UPTIME_HISTORY_MAX_ROWS)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
 }

--- a/crates/ignitify-db/src/tests.rs
+++ b/crates/ignitify-db/src/tests.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use ignitify_domain::{
     ApplicationBuilder, DnsRecord, DnsRecordType, DnsVerificationStatus, DomainName, ProjectInput,
     ProjectMemberRole, ServiceInput, ServiceSourceConfig, ServiceSpec, ServiceVariableInput,
@@ -11,7 +11,7 @@ use crate::{
     NewNotificationChannel, NewProvider, NewRemoteBuilder, NewRemoteServer, NewServerCertificate,
     NewServiceVariable, NewUptimeMonitor, ProjectActor, ProjectRemoveOutcome, ProjectUpdateOutcome,
     ProviderAuthMode, ProviderKind, RemoteServerAgentHeartbeat, ServerSettingsUpdate, ServiceActor,
-    ServiceMutationOutcome, UptimeCheckUpdate, UptimeMonitorUpdate,
+    ServiceMutationOutcome, UPTIME_HISTORY_MAX_ROWS, UptimeCheckUpdate, UptimeMonitorUpdate,
 };
 
 async fn database() -> Database {
@@ -83,6 +83,13 @@ async fn migrations_create_auth_storage() {
         .unwrap();
         assert_eq!(count, 1, "deployments must retain {column}");
     }
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'uptime_monitor_checks'",
+    )
+    .fetch_one(&database.pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 1, "uptime check history must be durable");
 }
 
 #[tokio::test]
@@ -352,6 +359,104 @@ async fn uptime_monitors_are_scoped_and_record_check_history() {
     assert_eq!(checked[0].status, "up");
     assert_eq!(checked[0].latency_ms, Some(42));
     assert_eq!(checked[0].history.last().map(String::as_str), Some("up"));
+
+    let mut expected_updated_at = checked[0].updated_at.clone();
+    for (index, status) in ["up", "up", "up", "down"].into_iter().enumerate() {
+        let checked_at = (Utc::now() - Duration::minutes(i64::from(4 - index as i32))).to_rfc3339();
+        assert!(
+            database
+                .uptime_monitors()
+                .record_check(
+                    &created.id,
+                    &expected_updated_at,
+                    UptimeCheckUpdate {
+                        status: status.to_owned(),
+                        latency_ms: Some(20),
+                        last_error: (status == "down").then(|| "connection failed".to_owned()),
+                        checked_at: checked_at.clone(),
+                    },
+                )
+                .await
+                .unwrap()
+        );
+        expected_updated_at = checked_at;
+    }
+    let history = database
+        .uptime_monitors()
+        .history_for_user(&owner_id, &created.id, 24, 100)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(history.checks.len(), 5);
+    assert_eq!(history.summary.failed_checks, 1);
+    assert_eq!(history.summary.status, "exhausted");
+    assert_eq!(
+        database
+            .uptime_monitors()
+            .budget_breached_count()
+            .await
+            .unwrap(),
+        1
+    );
+
+    let old_check_id = Uuid::new_v4().to_string();
+    let now = Utc::now();
+    let mut transaction = database.pool.begin().await.unwrap();
+    sqlx::query(
+        "INSERT INTO uptime_monitor_checks
+         (id, monitor_id, status, latency_ms, error, checked_at)
+         VALUES (?, ?, 'down', NULL, 'connection failed', ?)",
+    )
+    .bind(&old_check_id)
+    .bind(&created.id)
+    .bind((now - Duration::days(UPTIME_HISTORY_MAX_ROWS / 30)).to_rfc3339())
+    .execute(&mut *transaction)
+    .await
+    .unwrap();
+    for index in 0..=UPTIME_HISTORY_MAX_ROWS {
+        sqlx::query(
+            "INSERT INTO uptime_monitor_checks
+             (id, monitor_id, status, latency_ms, error, checked_at)
+             VALUES (?, ?, 'up', 20, NULL, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&created.id)
+        .bind((now - Duration::seconds(index)).to_rfc3339())
+        .execute(&mut *transaction)
+        .await
+        .unwrap();
+    }
+    transaction.commit().await.unwrap();
+    assert!(
+        database
+            .uptime_monitors()
+            .record_check(
+                &created.id,
+                &expected_updated_at,
+                UptimeCheckUpdate {
+                    status: "up".to_owned(),
+                    latency_ms: Some(20),
+                    last_error: None,
+                    checked_at: Utc::now().to_rfc3339(),
+                },
+            )
+            .await
+            .unwrap()
+    );
+    let retained_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM uptime_monitor_checks WHERE monitor_id = ?")
+            .bind(&created.id)
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+    assert_eq!(retained_count, UPTIME_HISTORY_MAX_ROWS);
+    let old_check_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM uptime_monitor_checks WHERE id = ?")
+            .bind(&old_check_id)
+            .fetch_one(&database.pool)
+            .await
+            .unwrap();
+    assert_eq!(old_check_count, 0);
 
     assert!(
         database

--- a/crates/ignitify-notifications/src/operational_alerts.rs
+++ b/crates/ignitify-notifications/src/operational_alerts.rs
@@ -17,6 +17,7 @@ enum OperationalAlert {
     RemoteAgentOffline,
     DomainVerificationFailed,
     CertificateNeedsAttention,
+    UptimeErrorBudgetExhausted,
 }
 
 const ALERTS: &[OperationalAlert] = &[
@@ -26,6 +27,7 @@ const ALERTS: &[OperationalAlert] = &[
     OperationalAlert::RemoteAgentOffline,
     OperationalAlert::DomainVerificationFailed,
     OperationalAlert::CertificateNeedsAttention,
+    OperationalAlert::UptimeErrorBudgetExhausted,
 ];
 
 impl OperationalAlert {
@@ -37,6 +39,7 @@ impl OperationalAlert {
             Self::RemoteAgentOffline => "remote_agent.offline",
             Self::DomainVerificationFailed => "domain.verification_failed",
             Self::CertificateNeedsAttention => "certificate.needs_attention",
+            Self::UptimeErrorBudgetExhausted => "uptime.error_budget_exhausted",
         }
     }
 
@@ -44,7 +47,13 @@ impl OperationalAlert {
         ALERTS.iter().copied().find(|alert| alert.key() == value)
     }
 
-    fn active(self, summary: &OperationsSummary, worker_ready: bool, now: DateTime<Utc>) -> bool {
+    fn active(
+        self,
+        summary: &OperationsSummary,
+        worker_ready: bool,
+        now: DateTime<Utc>,
+        uptime_budget_breached_count: i64,
+    ) -> bool {
         match self {
             Self::WorkerStalled => !worker_ready && summary.deployments.active_count > 0,
             Self::RetryExhausted => summary.deployments.recent_failed_retry_count > 0,
@@ -58,6 +67,7 @@ impl OperationalAlert {
                         && (!certificate.custom_certificate_selected
                             || certificate.stored_certificate_count == 0))
             }
+            Self::UptimeErrorBudgetExhausted => uptime_budget_breached_count > 0,
         }
     }
 
@@ -69,6 +79,7 @@ impl OperationalAlert {
             Self::RemoteAgentOffline => "Remote agent offline",
             Self::DomainVerificationFailed => "Domain verification failed",
             Self::CertificateNeedsAttention => "HTTPS certificate needs attention",
+            Self::UptimeErrorBudgetExhausted => "Uptime error budget exhausted",
         }
     }
 
@@ -97,6 +108,10 @@ impl OperationalAlert {
             ),
             Self::CertificateNeedsAttention => {
                 "HTTPS is enabled, but the configured custom certificate is missing or incomplete."
+                    .to_owned()
+            }
+            Self::UptimeErrorBudgetExhausted => {
+                "One or more uptime monitors exceeded the 1% failure budget over the last 24 hours."
                     .to_owned()
             }
         }
@@ -128,13 +143,22 @@ async fn evaluate_and_dispatch(
     worker_health: &dyn RuntimeHealth,
 ) -> Result<()> {
     let operations = database.operations();
-    let (summary, worker_ready) = tokio::join!(operations.summary(), worker_health.ready());
+    let monitors = database.uptime_monitors();
+    let (summary, worker_ready, uptime_budget_breached_count) = tokio::join!(
+        operations.summary(),
+        worker_health.ready(),
+        monitors.budget_breached_count(),
+    );
     let summary = summary?;
+    let uptime_budget_breached_count = uptime_budget_breached_count?;
     let now = Utc::now();
 
     for alert in ALERTS {
         let _ = operations
-            .transition_alert(alert.key(), alert.active(&summary, worker_ready, now))
+            .transition_alert(
+                alert.key(),
+                alert.active(&summary, worker_ready, now, uptime_budget_breached_count),
+            )
             .await?;
     }
 
@@ -269,11 +293,11 @@ mod tests {
         let now = Utc::now();
         let mut value = summary();
         value.deployments.active_count = 1;
-        assert!(OperationalAlert::WorkerStalled.active(&value, false, now));
-        assert!(!OperationalAlert::WorkerStalled.active(&value, true, now));
+        assert!(OperationalAlert::WorkerStalled.active(&value, false, now, 0));
+        assert!(!OperationalAlert::WorkerStalled.active(&value, true, now, 0));
 
         value.deployments.recent_failed_retry_count = 1;
-        assert!(OperationalAlert::RetryExhausted.active(&value, true, now));
+        assert!(OperationalAlert::RetryExhausted.active(&value, true, now, 0));
 
         value.backup = BackupOperationsSummary {
             configured: true,
@@ -285,11 +309,12 @@ mod tests {
                 completed_at: Some((now - Duration::hours(3)).to_rfc3339()),
             }),
         };
-        assert!(OperationalAlert::BackupStale.active(&value, true, now));
+        assert!(OperationalAlert::BackupStale.active(&value, true, now, 0));
 
         value.remote_agents.offline_count = 1;
-        assert!(OperationalAlert::RemoteAgentOffline.active(&value, true, now));
+        assert!(OperationalAlert::RemoteAgentOffline.active(&value, true, now, 0));
         value.domains.failed_count = 1;
-        assert!(OperationalAlert::DomainVerificationFailed.active(&value, true, now));
+        assert!(OperationalAlert::DomainVerificationFailed.active(&value, true, now, 0));
+        assert!(OperationalAlert::UptimeErrorBudgetExhausted.active(&value, true, now, 1));
     }
 }

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -58,4 +58,10 @@ Repositories receive the actor and evaluate access before returning data. Handle
 
 `GET /health` is an unauthenticated basic probe. `GET /api/v1/runtime/status` checks the database, runtime, worker, ingress, and host metrics as `ready` or `unavailable`. Detailed system metrics are available at `GET /api/v1/runtime/metrics`; Docker inventory is available through the runtime endpoints.
 
+Uptime monitor checks are persisted separately from monitor configuration with a
+30-day and 1,000-check per-monitor bound. Owner-scoped history exposes
+timestamped status, latency, and safe errors for 24-hour, 7-day, or 30-day
+inspection. A 99% availability target over the most recent 24 hours raises a
+deduplicated operational alert only after at least three checks.
+
 Deployment events and logs use SSE. Streams can replay from a stored cursor (`Last-Event-ID` or `after`) and send a snapshot when the client's cursor is older than the event retention window.

--- a/docs/id/concepts/architecture.md
+++ b/docs/id/concepts/architecture.md
@@ -58,4 +58,10 @@ Repository menerima actor dan mengevaluasi akses sebelum menghasilkan data. Hand
 
 `GET /health` adalah probe dasar tanpa autentikasi. `GET /api/v1/runtime/status` memeriksa database, runtime, worker, ingress, dan metric host sebagai status `ready` atau `unavailable`. Metric sistem detail ada pada `GET /api/v1/runtime/metrics`; inventaris Docker tersedia melalui endpoint runtime.
 
+Check monitor uptime disimpan terpisah dari konfigurasi monitor dengan batas 30
+hari dan 1.000 check untuk setiap monitor. History per owner menampilkan status,
+latency, dan error aman bertimestamp untuk inspeksi 24 jam, 7 hari, atau 30 hari.
+Target availability 99% dalam 24 jam terakhir hanya mengirim alert operasional
+yang terdeduplikasi setelah setidaknya tiga check tersedia.
+
 Event dan log deployment menggunakan SSE. Stream dapat melakukan replay dari cursor yang disimpan (`Last-Event-ID` atau `after`) dan mengirim snapshot jika cursor client lebih tua dari retensi event.

--- a/docs/id/reference/api.md
+++ b/docs/id/reference/api.md
@@ -121,6 +121,21 @@ Environment project memakai bentuk berikut. Untuk mempertahankan secret yang sud
 
 Submit deployment membutuhkan header idempotency key sesuai kontrak client. Request produksi mengembalikan objek `approval` dan tetap pending sampai owner project atau operator platform menyetujuinya. Respons menampilkan bukti source/image immutable di `source_identity` saat sudah diketahui. Untuk melanjutkan SSE, kirim `Last-Event-ID` atau parameter query `after=<sequence>`. Stream mengirim event `snapshot` jika cursor lebih lama dari data yang masih tersedia, heartbeat sekitar 15 detik, dan event `log` untuk stream log.
 
+## Monitoring uptime
+
+| Method            | Path                                            | Keterangan                                     |
+| ----------------- | ----------------------------------------------- | ---------------------------------------------- |
+| `GET`, `POST`     | `/api/v1/uptime-monitors`                      | List atau buat monitor milik actor.            |
+| `PATCH`, `DELETE` | `/api/v1/uptime-monitors/{monitor_id}`         | Ubah atau hapus monitor milik actor.           |
+| `GET`             | `/api/v1/uptime-monitors/{monitor_id}/history` | Baca riwayat check terbatas dan availability.  |
+
+History menerima `hours=1..720` dan `limit=1..500`; hasilnya tidak lebih dari
+30 hari atau 1.000 check tersimpan per monitor. Ringkasan availability mencakup
+seluruh window yang dipilih walaupun titik grafik dibatasi. Monitor dengan
+minimal tiga check akan mengirim `operations.alert` yang terdeduplikasi saat
+gagal memakai lebih dari error budget 1% dalam 24 jam; alert resolved dikirim
+setelah pulih.
+
 ## Sumber kontrak
 
 Daftar route di atas berasal dari `ignitify/crates/ignitify-api/src/routes.rs`. DTO respons dan validasi spesifik berada pada `handlers/` dan `ignitify-domain`. Saat mengubah kontrak, perbarui route, typed client dashboard, test, dan halaman ini dalam satu perubahan.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -120,6 +120,21 @@ Project environments use this shape. To keep an existing secret, send `value: nu
 
 Deployment submission requires an idempotency key header according to the client contract. Production requests return an `approval` object and remain pending until a project owner or platform operator approves them. Responses expose immutable source/image evidence under `source_identity` when it is known. To resume SSE, send `Last-Event-ID` or the `after=<sequence>` query parameter. Streams send a `snapshot` event when the cursor is older than the retained data, a heartbeat about every 15 seconds, and `log` events on the log stream.
 
+## Uptime monitoring
+
+| Method            | Path                                            | Description                                  |
+| ----------------- | ----------------------------------------------- | -------------------------------------------- |
+| `GET`, `POST`     | `/api/v1/uptime-monitors`                      | List or create monitors owned by the actor.  |
+| `PATCH`, `DELETE` | `/api/v1/uptime-monitors/{monitor_id}`         | Update or remove an owned monitor.           |
+| `GET`             | `/api/v1/uptime-monitors/{monitor_id}/history` | Read bounded check history and availability. |
+
+History accepts `hours=1..720` and `limit=1..500`; it returns no more than 30
+days or 1,000 retained checks per monitor. The availability summary covers the
+full selected window even when the returned chart points are capped. A monitor
+with at least three checks raises the transition-deduplicated `operations.alert`
+when failures consume more than the 1% 24-hour error budget; a resolved alert
+is delivered when it recovers.
+
 ## Contract sources
 
 The routes above come from `ignitify/crates/ignitify-api/src/routes.rs`. Response DTOs and specific validation live in `handlers/` and `ignitify-domain`. When changing a contract, update the route, typed dashboard client, tests, and this page in one change.

--- a/frontend/src/components/uptime/UptimeMonitorHistoryPanel.vue
+++ b/frontend/src/components/uptime/UptimeMonitorHistoryPanel.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { Button } from "@/components/ui/button";
+import type { UptimeCheckHistoryEntry, UptimeMonitorHistory } from "@/lib/api/uptime-monitors";
+
+const props = defineProps<{
+  history?: UptimeMonitorHistory;
+  loading: boolean;
+  error: string | null;
+  windowHours: number;
+}>();
+
+const emit = defineEmits<{ selectWindow: [hours: number] }>();
+
+const { t } = useI18n();
+
+const recentChecks = computed(() => props.history?.checks.slice(-8).reverse() ?? []);
+const windows = [24, 24 * 7, 24 * 30] as const;
+
+function percentage(value: number | null | undefined): string {
+  return value === null || value === undefined ? "-" : `${value.toFixed(2)}%`;
+}
+
+function statusClass(status: string): string {
+  if (status === "up" || status === "healthy") return "text-[var(--status-healthy)]";
+  if (status === "down" || status === "exhausted") return "text-destructive";
+  if (status === "warning") return "text-signal-orange";
+  return "text-muted-foreground";
+}
+
+function checkClass(check: UptimeCheckHistoryEntry): string {
+  return check.status === "up" ? "bg-[var(--status-healthy)]" : "bg-destructive";
+}
+
+function formatCheckTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "-";
+  return new Intl.DateTimeFormat(undefined, {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(date);
+}
+
+function windowLabel(hours: number): string {
+  if (hours < 48) return "24H";
+  if (hours < 24 * 30) return "7D";
+  return "30D";
+}
+</script>
+
+<template>
+  <section class="border-t border-border px-4 py-4 sm:px-5" aria-live="polite">
+    <div class="flex flex-wrap items-start justify-between gap-2">
+      <div>
+        <p class="font-mono text-[10px] text-muted-foreground uppercase">
+          {{ t("uptimeHistory.title") }}
+        </p>
+        <p v-if="history" class="mt-1 text-xs text-muted-foreground">
+          {{ t("uptimeHistory.retention", { days: history.retention_days }) }}
+        </p>
+      </div>
+      <div class="flex items-center gap-3">
+        <div
+          class="flex overflow-hidden rounded-[3px] border border-border"
+          role="group"
+          :aria-label="t('uptimeHistory.windowSelector')"
+        >
+          <Button
+            v-for="hours in windows"
+            :key="hours"
+            size="sm"
+            variant="ghost"
+            type="button"
+            class="h-7 min-w-9 rounded-none px-2 font-mono text-[10px]"
+            :class="windowHours === hours ? 'bg-muted text-foreground' : 'text-muted-foreground'"
+            :disabled="loading"
+            :aria-pressed="windowHours === hours"
+            @click="emit('selectWindow', hours)"
+          >
+            {{ windowLabel(hours) }}
+          </Button>
+        </div>
+        <p
+          v-if="history"
+          class="font-mono text-xs uppercase"
+          :class="statusClass(history.summary.status)"
+        >
+          {{ t(`uptimeHistory.status.${history.summary.status}`) }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="loading" class="mt-4 h-20 animate-pulse rounded-[3px] bg-muted" role="status" />
+    <p v-else-if="error" class="mt-4 text-xs text-destructive" role="alert">{{ error }}</p>
+    <template v-else-if="history">
+      <div
+        class="mt-4 grid divide-y divide-border border-y border-border sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+      >
+        <div class="min-w-0 py-2 sm:pr-3">
+          <p class="font-mono text-[10px] text-muted-foreground uppercase">
+            {{ t("uptimeHistory.availability") }}
+          </p>
+          <p class="mt-1 font-mono text-sm">
+            {{ percentage(history.summary.availability_percentage) }}
+          </p>
+        </div>
+        <div class="min-w-0 py-2 sm:px-3">
+          <p class="font-mono text-[10px] text-muted-foreground uppercase">
+            {{ t("uptimeHistory.budgetConsumed") }}
+          </p>
+          <p class="mt-1 font-mono text-sm" :class="statusClass(history.summary.status)">
+            {{ percentage(history.summary.budget_consumed_percentage) }}
+          </p>
+        </div>
+        <div class="min-w-0 py-2 sm:pl-3">
+          <p class="font-mono text-[10px] text-muted-foreground uppercase">
+            {{ t("uptimeHistory.checks") }}
+          </p>
+          <p class="mt-1 font-mono text-sm">
+            {{ history.summary.successful_checks }}/{{ history.summary.total_checks }}
+          </p>
+        </div>
+      </div>
+
+      <div v-if="history.checks.length" class="mt-4">
+        <div class="flex items-center justify-between gap-3">
+          <p class="font-mono text-[10px] text-muted-foreground uppercase">
+            {{ t("uptimeHistory.timeline") }}
+          </p>
+          <p class="font-mono text-[10px] text-muted-foreground">
+            {{ t("uptimeHistory.window", { hours: history.summary.window_hours }) }}
+          </p>
+        </div>
+        <div class="mt-2 flex h-5 gap-px" :aria-label="t('uptimeHistory.timeline')">
+          <span
+            v-for="check in history.checks"
+            :key="`${check.checked_at}-${check.status}`"
+            class="min-w-px flex-1 rounded-[1px]"
+            :class="checkClass(check)"
+            :title="`${formatCheckTime(check.checked_at)}: ${check.status}`"
+          />
+        </div>
+      </div>
+      <p v-else class="mt-4 text-xs text-muted-foreground">{{ t("uptimeHistory.noData") }}</p>
+
+      <ol v-if="recentChecks.length" class="mt-4 divide-y divide-border border-y border-border">
+        <li
+          v-for="check in recentChecks"
+          :key="check.checked_at"
+          class="grid gap-1 py-2 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center sm:gap-3"
+        >
+          <span class="font-mono text-[10px] uppercase" :class="statusClass(check.status)">
+            {{ check.status }}
+          </span>
+          <p class="truncate text-[11px] text-muted-foreground" :title="check.error ?? undefined">
+            {{ check.error ?? formatCheckTime(check.checked_at) }}
+          </p>
+          <span class="font-mono text-[10px] text-muted-foreground">
+            {{ check.latency_ms === null ? "-" : `${check.latency_ms} ms` }}
+          </span>
+        </li>
+      </ol>
+    </template>
+  </section>
+</template>

--- a/frontend/src/composables/useUptimeMonitorHistory.spec.ts
+++ b/frontend/src/composables/useUptimeMonitorHistory.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({ getHistory: vi.fn() }));
+
+vi.mock("@/lib/api/uptime-monitors", () => ({
+  apiGetUptimeMonitorHistory: api.getHistory,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("useUptimeMonitorHistory", () => {
+  it("loads the bounded 24-hour history and clears it after a monitor changes", async () => {
+    api.getHistory.mockResolvedValue({
+      success: true,
+      data: {
+        monitor_id: "monitor-1",
+        retention_days: 30,
+        checks: [],
+        summary: {
+          window_hours: 24,
+          total_checks: 4,
+          successful_checks: 3,
+          failed_checks: 1,
+          availability_percentage: 75,
+          error_budget_percentage: 0,
+          budget_consumed_percentage: 2500,
+          status: "exhausted",
+        },
+      },
+    });
+
+    const { useUptimeMonitorHistory } = await import("./useUptimeMonitorHistory");
+    const history = useUptimeMonitorHistory();
+    await history.loadHistory("monitor-1");
+
+    expect(api.getHistory.mock.calls).toEqual([["monitor-1", { hours: 24, limit: 500 }]]);
+    expect(history.histories.value["monitor-1"]?.summary.status).toBe("exhausted");
+
+    history.clearHistory("monitor-1");
+    expect(history.histories.value["monitor-1"]).toBeUndefined();
+  });
+});

--- a/frontend/src/composables/useUptimeMonitorHistory.ts
+++ b/frontend/src/composables/useUptimeMonitorHistory.ts
@@ -1,0 +1,45 @@
+import { shallowRef, triggerRef } from "vue";
+import { apiGetUptimeMonitorHistory, type UptimeMonitorHistory } from "@/lib/api/uptime-monitors";
+
+const histories = shallowRef<Record<string, UptimeMonitorHistory>>({});
+const loadingMonitorId = shallowRef<string | null>(null);
+const error = shallowRef<string | null>(null);
+
+export function useUptimeMonitorHistory() {
+  async function loadHistory(
+    monitorId: string,
+    windowHours = 24,
+  ): Promise<UptimeMonitorHistory | null> {
+    loadingMonitorId.value = monitorId;
+    error.value = null;
+    try {
+      const result = await apiGetUptimeMonitorHistory(monitorId, {
+        hours: windowHours,
+        limit: 500,
+      });
+      if (!result.success) {
+        error.value = result.error ?? "Unable to load monitor history.";
+        return null;
+      }
+      histories.value[monitorId] = result.data;
+      triggerRef(histories);
+      return result.data;
+    } finally {
+      if (loadingMonitorId.value === monitorId) loadingMonitorId.value = null;
+    }
+  }
+
+  function clearHistory(monitorId: string) {
+    if (!(monitorId in histories.value)) return;
+    delete histories.value[monitorId];
+    triggerRef(histories);
+  }
+
+  return {
+    histories,
+    loadingMonitorId,
+    error,
+    loadHistory,
+    clearHistory,
+  };
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -204,6 +204,25 @@ export default {
     lineCount: "{shown} of {total} lines",
     noMatches: "No matching deployment log lines.",
   },
+  uptimeHistory: {
+    title: "24-hour history",
+    retention: "Detailed checks retained for {days} days",
+    availability: "Availability",
+    budgetConsumed: "Error budget used",
+    checks: "Successful checks",
+    timeline: "Check timeline",
+    window: "Last {hours} hours",
+    windowSelector: "History time range",
+    noData: "No completed checks in this window.",
+    view: "View history",
+    hide: "Hide history",
+    status: {
+      healthy: "Healthy",
+      warning: "Budget warning",
+      exhausted: "Budget exhausted",
+      insufficient_data: "Awaiting data",
+    },
+  },
   ai: {
     actions: {
       ask: "Ask AI",

--- a/frontend/src/i18n/locales/id.ts
+++ b/frontend/src/i18n/locales/id.ts
@@ -202,6 +202,25 @@ export default {
     lineCount: "{shown} dari {total} baris",
     noMatches: "Tidak ada baris log deployment yang cocok.",
   },
+  uptimeHistory: {
+    title: "Riwayat 24 jam",
+    retention: "Pemeriksaan detail disimpan selama {days} hari",
+    availability: "Ketersediaan",
+    budgetConsumed: "Budget error terpakai",
+    checks: "Pemeriksaan berhasil",
+    timeline: "Linimasa pemeriksaan",
+    window: "{hours} jam terakhir",
+    windowSelector: "Rentang waktu riwayat",
+    noData: "Belum ada pemeriksaan selesai dalam rentang ini.",
+    view: "Lihat riwayat",
+    hide: "Sembunyikan riwayat",
+    status: {
+      healthy: "Sehat",
+      warning: "Peringatan budget",
+      exhausted: "Budget habis",
+      insufficient_data: "Menunggu data",
+    },
+  },
   ai: {
     actions: {
       ask: "Tanya AI",

--- a/frontend/src/lib/api/uptime-monitors.ts
+++ b/frontend/src/lib/api/uptime-monitors.ts
@@ -28,6 +28,33 @@ export interface UptimeMonitorInput {
   enabled: boolean;
 }
 
+export type UptimeAvailabilityStatus = "healthy" | "warning" | "exhausted" | "insufficient_data";
+
+export interface UptimeCheckHistoryEntry {
+  status: Exclude<UptimeMonitorStatus, "pending">;
+  latency_ms: number | null;
+  error: string | null;
+  checked_at: string;
+}
+
+export interface UptimeMonitorHistorySummary {
+  window_hours: number;
+  total_checks: number;
+  successful_checks: number;
+  failed_checks: number;
+  availability_percentage: number | null;
+  error_budget_percentage: number | null;
+  budget_consumed_percentage: number | null;
+  status: UptimeAvailabilityStatus;
+}
+
+export interface UptimeMonitorHistory {
+  monitor_id: string;
+  retention_days: number;
+  checks: UptimeCheckHistoryEntry[];
+  summary: UptimeMonitorHistorySummary;
+}
+
 const endpoint = "/uptime-monitors";
 
 export function apiListUptimeMonitors(): Promise<ApiResult<UptimeMonitorSummary[]>> {
@@ -57,4 +84,17 @@ export function apiDeleteUptimeMonitor(monitorId: string): Promise<ApiResult<voi
   return apiFetch<void>(`${endpoint}/${encodeURIComponent(monitorId)}`, {
     method: "DELETE",
   });
+}
+
+export function apiGetUptimeMonitorHistory(
+  monitorId: string,
+  options: { hours?: number; limit?: number } = {},
+): Promise<ApiResult<UptimeMonitorHistory>> {
+  const params = new URLSearchParams();
+  if (options.hours !== undefined) params.set("hours", String(options.hours));
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  const query = params.size > 0 ? `?${params.toString()}` : "";
+  return apiFetch<UptimeMonitorHistory>(
+    `${endpoint}/${encodeURIComponent(monitorId)}/history${query}`,
+  );
 }

--- a/frontend/src/views/UptimeView.vue
+++ b/frontend/src/views/UptimeView.vue
@@ -6,6 +6,7 @@ import {
   Ellipsis,
   ExternalLink,
   Globe2,
+  History,
   Plus,
   RefreshCw,
   Server,
@@ -13,6 +14,8 @@ import {
 } from "@lucide/vue";
 import { computed, onMounted, onUnmounted, shallowRef } from "vue";
 import { toast } from "vue-sonner";
+import { useI18n } from "vue-i18n";
+import UptimeMonitorHistoryPanel from "@/components/uptime/UptimeMonitorHistoryPanel.vue";
 import UptimeMonitorDialog from "@/components/uptime/UptimeMonitorDialog.vue";
 import { Button } from "@/components/ui/button";
 import {
@@ -38,9 +41,12 @@ import {
   type UptimeMonitorInput,
   type UptimeMonitorStatus,
 } from "@/composables/useUptimeMonitors";
+import { useUptimeMonitorHistory } from "@/composables/useUptimeMonitorHistory";
 
 type DisplayStatus = UptimeMonitorStatus | "paused";
 type StatusFilter = "all" | DisplayStatus;
+
+const { t } = useI18n();
 
 const {
   monitors,
@@ -53,11 +59,20 @@ const {
   removeMonitor,
   reloadMonitors,
 } = useUptimeMonitors();
+const {
+  histories,
+  loadingMonitorId,
+  error: historyError,
+  loadHistory,
+  clearHistory,
+} = useUptimeMonitorHistory();
 const search = shallowRef("");
 const statusFilter = shallowRef<StatusFilter>("all");
 const dialogOpen = shallowRef(false);
 const editingMonitor = shallowRef<UptimeMonitor | null>(null);
 const monitorPendingRemoval = shallowRef<UptimeMonitor | null>(null);
+const expandedHistoryMonitorId = shallowRef<string | null>(null);
+const historyWindowHours = shallowRef(24);
 const lastUpdated = shallowRef(new Date());
 let refreshTimer: number | undefined;
 
@@ -188,6 +203,7 @@ async function saveMonitor(input: UptimeMonitorInput) {
     });
     return;
   }
+  if (existing) clearHistory(existing.id);
   lastUpdated.value = new Date();
   updateDialog(false);
   toast.success(existing ? "Monitor updated" : "Monitor added", { description: result.name });
@@ -208,8 +224,24 @@ async function removeSelectedMonitor() {
     return;
   }
   monitorPendingRemoval.value = null;
+  clearHistory(monitor.id);
+  if (expandedHistoryMonitorId.value === monitor.id) expandedHistoryMonitorId.value = null;
   lastUpdated.value = new Date();
   toast.success("Monitor removed", { description: monitor.name });
+}
+
+async function toggleHistory(monitor: UptimeMonitor) {
+  if (expandedHistoryMonitorId.value === monitor.id) {
+    expandedHistoryMonitorId.value = null;
+    return;
+  }
+  expandedHistoryMonitorId.value = monitor.id;
+  await loadHistory(monitor.id, historyWindowHours.value);
+}
+
+async function selectHistoryWindow(monitor: UptimeMonitor, hours: number) {
+  historyWindowHours.value = hours;
+  await loadHistory(monitor.id, hours);
 }
 
 async function reloadConfiguration(showSuccess = false) {
@@ -486,8 +518,33 @@ onUnmounted(() => {
                   :class="historyClass(state)"
                 />
               </div>
+              <Button
+                class="mt-3 w-full"
+                size="sm"
+                variant="outline"
+                type="button"
+                :disabled="loadingMonitorId === monitor.id"
+                @click="toggleHistory(monitor)"
+              >
+                <History class="size-3.5" :stroke-width="1.5" />
+                {{
+                  t(
+                    expandedHistoryMonitorId === monitor.id
+                      ? "uptimeHistory.hide"
+                      : "uptimeHistory.view",
+                  )
+                }}
+              </Button>
             </div>
           </div>
+          <UptimeMonitorHistoryPanel
+            v-if="expandedHistoryMonitorId === monitor.id"
+            :history="histories[monitor.id]"
+            :loading="loadingMonitorId === monitor.id"
+            :error="historyError"
+            :window-hours="historyWindowHours"
+            @select-window="selectHistoryWindow(monitor, $event)"
+          />
         </article>
       </div>
 

--- a/infra/operations/runbooks.md
+++ b/infra/operations/runbooks.md
@@ -40,10 +40,28 @@ The operational dispatcher evaluates these bounded conditions every 30 seconds:
 - `domain.verification_failed`: at least one domain is in failed state.
 - `certificate.needs_attention`: HTTPS is enabled with an incomplete custom
   certificate configuration.
+- `uptime.error_budget_exhausted`: at least one monitor with three or more
+  checks exceeded the 1% failure budget over the latest 24 hours.
 
 Each condition sends one `operations.alert` notification when raised and one
 when resolved. Repeated evaluator cycles do not create additional deliveries;
 delivery history is the source of truth for retry diagnostics.
+
+## Uptime Error Budget
+
+1. Open the affected monitor history and compare the 24-hour, 7-day, and
+   30-day views. The endpoint retains at most 30 days and 1,000 checks, so
+   preserve the safe timestamp, status, latency, and error evidence before it
+   expires.
+2. Confirm whether failures are isolated to one endpoint, check type, or
+   deployment window. Do not add a private or loopback target to test around
+   the existing SSRF policy.
+3. Check the 24-hour availability summary. The alert requires at least three
+   checks and is raised only after failures exceed the 1% budget; it resolves
+   automatically after the window recovers.
+4. Correlate the time range with deployment and notification history before
+   changing the monitored service. Treat monitor errors as bounded diagnostics,
+   never as permission to expose runtime ports or credentials.
 
 ## Failed Deployment
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -203,7 +203,7 @@ Target: days 61-90.
   immutable source commit and image digest in deployment history.
 - [x] Add webhook delivery history and clear retry diagnostics without exposing
   credentials or payloads.
-- [ ] Retain and visualize monitoring history using a bounded retention policy;
+- [x] Retain and visualize monitoring history using a bounded retention policy;
   define uptime and error-budget alerting.
 
 ### Definition Of Done
@@ -212,7 +212,7 @@ Target: days 61-90.
   approval trail.
 - [ ] Supply-chain signals are visible before deployment and can be governed by
   policy.
-- [ ] Historical monitoring provides enough context to investigate regressions and
+- [x] Historical monitoring provides enough context to investigate regressions and
   alert fatigue.
 
 Evidence: migration `0036_deployment_supply_chain_reports.sql` stores an
@@ -232,6 +232,15 @@ records use the deployment correlation ID. The API and deployment UI expose the
 approval trail and immutable source/image identity when it is known; database,
 control-plane, API, and frontend regression coverage verifies that pending work
 is never executed.
+
+Evidence: migration `0038_uptime_check_history.sql` records timestamped safe
+uptime check outcomes separately from the bounded 30-check status strip. It
+retains at most 30 days and 1,000 checks for each monitor, while the owner-scoped
+history API caps chart responses at 500 points and calculates availability from
+the complete selected window. The uptime UI exposes 24-hour, 7-day, and 30-day
+views. A monitor with at least three checks sends a transition-deduplicated
+operational alert after it consumes the 1% 24-hour error budget, and sends a
+resolved notification when it recovers.
 
 ## Deferred Until The Foundations Are Complete
 


### PR DESCRIPTION
## Summary
- Persist timestamped uptime checks with a 30-day and 1,000-record per-monitor retention bound.
- Add owner-scoped history with 24-hour, 7-day, and 30-day availability/error-budget views.
- Raise deduplicated operational alerts when a monitor exceeds its 1% 24-hour error budget after sufficient samples.

## Verification
- cargo test --workspace --quiet -- --test-threads=1
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm run check
- pnpm run test
- pnpm run build
- CI=true pnpm run test:e2e