### PR TITLE
feat: enforce deployment supply-chain policy

### DIFF
--- a/crates/ignitify-api/src/handlers/mod.rs
+++ b/crates/ignitify-api/src/handlers/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod runtime;
 pub(crate) mod services;
 pub(crate) mod settings;
 pub(crate) mod streams;
+pub(crate) mod supply_chain_policy;
 pub(crate) mod terminal;
 pub(crate) mod uptime_monitors;
 pub(crate) mod webhooks;

--- a/crates/ignitify-api/src/handlers/supply_chain_policy.rs
+++ b/crates/ignitify-api/src/handlers/supply_chain_policy.rs
@@ -1,0 +1,94 @@
+use axum::{
+    Json,
+    extract::{ConnectInfo, Extension, State},
+    http::HeaderMap,
+};
+use ignitify_db::AuditOutcome;
+use ignitify_domain::{SupplyChainEnforcement, SupplyChainPolicy};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    audit,
+    error::ApiError,
+    extract::{require_actor, require_same_origin_request},
+    state::AppState,
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct SupplyChainPolicyRequest {
+    enforcement: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SupplyChainPolicyResponse {
+    enforcement: SupplyChainEnforcement,
+    updated_at: String,
+}
+
+impl From<SupplyChainPolicy> for SupplyChainPolicyResponse {
+    fn from(policy: SupplyChainPolicy) -> Self {
+        Self {
+            enforcement: policy.enforcement,
+            updated_at: policy.updated_at,
+        }
+    }
+}
+
+pub(crate) async fn get(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<SupplyChainPolicyResponse>, ApiError> {
+    require_platform_operator(&state, &headers).await?;
+    let policy = state.database.deployments().supply_chain_policy().await?;
+    Ok(Json(policy.into()))
+}
+
+pub(crate) async fn update(
+    State(state): State<AppState>,
+    peer: Option<Extension<ConnectInfo<std::net::SocketAddr>>>,
+    headers: HeaderMap,
+    Json(request): Json<SupplyChainPolicyRequest>,
+) -> Result<Json<SupplyChainPolicyResponse>, ApiError> {
+    let actor = require_platform_operator(&state, &headers).await?;
+    require_same_origin_request(&state, &headers)?;
+    let enforcement = request
+        .enforcement
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+        .try_into()
+        .map_err(|_| ApiError::BadRequest("supply-chain enforcement mode is invalid"))?;
+    let policy = state
+        .database
+        .deployments()
+        .update_supply_chain_enforcement(enforcement)
+        .await?;
+    audit::record(
+        &state,
+        Some(&actor),
+        &headers,
+        peer.as_deref(),
+        "supply_chain_policy.update",
+        Some("supply_chain_policy"),
+        Some("global"),
+        AuditOutcome::Success,
+    )
+    .await?;
+    if let Some(control) = &state.control {
+        let _ = control.wake_worker();
+    }
+    Ok(Json(policy.into()))
+}
+
+async fn require_platform_operator(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<ignitify_auth::AuthenticatedUser, ApiError> {
+    let actor = require_actor(state, headers).await?;
+    if actor.has_platform_operator_access() {
+        Ok(actor)
+    } else {
+        Err(ApiError::Forbidden)
+    }
+}

--- a/crates/ignitify-api/src/openapi.rs
+++ b/crates/ignitify-api/src/openapi.rs
@@ -244,6 +244,17 @@ protected_mutation!(
     "/api/v1/settings/infrastructure",
     "Settings"
 );
+protected_get!(
+    supply_chain_policy_doc,
+    "/api/v1/settings/supply-chain-policy",
+    "Settings"
+);
+protected_mutation!(
+    update_supply_chain_policy_doc,
+    put,
+    "/api/v1/settings/supply-chain-policy",
+    "Settings"
+);
 protected_mutation!(
     create_infrastructure_certificate_doc,
     post,
@@ -649,6 +660,8 @@ protected_get!(terminal_doc, "/api/v1/terminal", "Terminal");
         ai::chat,
         infrastructure_settings_doc,
         update_infrastructure_settings_doc,
+        supply_chain_policy_doc,
+        update_supply_chain_policy_doc,
         create_infrastructure_certificate_doc,
         remove_infrastructure_certificate_doc,
         server_settings_doc,

--- a/crates/ignitify-api/src/routes.rs
+++ b/crates/ignitify-api/src/routes.rs
@@ -90,6 +90,10 @@ pub(crate) fn router(state: AppState) -> Router {
             get(handlers::settings::get).patch(handlers::settings::update),
         )
         .route(
+            "/api/v1/settings/supply-chain-policy",
+            get(handlers::supply_chain_policy::get).put(handlers::supply_chain_policy::update),
+        )
+        .route(
             "/api/v1/settings/infrastructure/certificates",
             axum::routing::post(handlers::settings::create_certificate),
         )

--- a/crates/ignitify-api/src/tests.rs
+++ b/crates/ignitify-api/src/tests.rs
@@ -711,6 +711,7 @@ async fn openapi_document_and_swagger_ui_are_served() {
         "/api/v1/providers/{provider_id}/repositories",
         "/api/v1/runtime/containers/{container_id}/details",
         "/api/v1/settings/infrastructure",
+        "/api/v1/settings/supply-chain-policy",
         "/api/v1/operations/health-summary",
         "/api/v1/remote-servers/{server_id}/agent/install",
         "/api/v1/projects/{project_id}/services",
@@ -1204,6 +1205,103 @@ async fn infrastructure_settings_require_admin_and_persist_validated_updates() {
         .await
         .unwrap();
     assert_eq!(invalid_fallback.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn supply_chain_policy_requires_an_operator_and_persists_valid_modes() {
+    let state = state().await;
+    let token = session_token(&state).await;
+    let app = router(
+        state.auth.clone(),
+        state.database.clone(),
+        state.services.clone(),
+        state.control.clone(),
+        state.runtime_health.clone(),
+        state.worker_health.clone(),
+        state.secure_cookies,
+        Arc::from([]),
+    );
+
+    let unauthenticated = app
+        .clone()
+        .oneshot(request(
+            "GET",
+            "/api/v1/settings/supply-chain-policy",
+            None,
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+    let password_hash = Argon2::default()
+        .hash_password(b"password123", &SaltString::generate(&mut OsRng))
+        .unwrap()
+        .to_string();
+    state
+        .database
+        .users()
+        .create("policy-user", &password_hash, DatabaseUserRole::User)
+        .await
+        .unwrap();
+    let user_token = state
+        .auth
+        .login("policy-user", "password123")
+        .await
+        .unwrap()
+        .access_token;
+    let forbidden = app
+        .clone()
+        .oneshot(request(
+            "GET",
+            "/api/v1/settings/supply-chain-policy",
+            Some(&user_token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(forbidden.status(), StatusCode::FORBIDDEN);
+
+    let invalid = app
+        .clone()
+        .oneshot(request(
+            "PUT",
+            "/api/v1/settings/supply-chain-policy",
+            Some(&token),
+            r#"{"enforcement":"block-everything"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
+    let updated = app
+        .clone()
+        .oneshot(request(
+            "PUT",
+            "/api/v1/settings/supply-chain-policy",
+            Some(&token),
+            r#"{"enforcement":"require-provenance"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(updated.status(), StatusCode::OK);
+    let body = updated.into_body().collect().await.unwrap().to_bytes();
+    let policy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(policy["enforcement"], "require-provenance");
+    assert!(policy["updated_at"].is_string());
+
+    let persisted = app
+        .oneshot(request(
+            "GET",
+            "/api/v1/settings/supply-chain-policy",
+            Some(&token),
+            "",
+        ))
+        .await
+        .unwrap();
+    let body = persisted.into_body().collect().await.unwrap().to_bytes();
+    let policy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(policy["enforcement"], "require-provenance");
 }
 
 #[tokio::test]

--- a/crates/ignitify-control-plane/src/deployment_control.rs
+++ b/crates/ignitify-control-plane/src/deployment_control.rs
@@ -73,11 +73,13 @@ impl ControlHandle {
         let variables_ciphertext = self.snapshot_variables(&service)?;
         let spec = service.spec.clone();
         let source_config = service.source_config.clone();
+        let supply_chain_policy = self.deployments.supply_chain_policy().await?;
         let supply_chain_report = Some(evaluate_supply_chain_report(
             &spec,
             source_config.as_ref(),
             source_revision,
             None,
+            supply_chain_policy.enforcement,
             Utc::now().to_rfc3339(),
         ));
         let outcome = self

--- a/crates/ignitify-control-plane/src/implementation.rs
+++ b/crates/ignitify-control-plane/src/implementation.rs
@@ -322,7 +322,10 @@ where
         deployment.id.as_str(),
     );
     source_logs.system("Source build started").await?;
-    let runtime_deployment = match source_build.build(&deployment, &source_logs).await {
+    let (runtime_deployment, source_revision) = match source_build
+        .build(&deployment, &source_logs)
+        .await
+    {
         Ok(Some(output)) => {
             source_logs.system("Source build completed").await?;
             if deployments.cancel_requested(deployment.id.as_str()).await? {
@@ -344,19 +347,12 @@ where
             if let Some(spec) = runtime_spec {
                 runtime_deployment.spec = spec;
             }
-            let report = evaluate_supply_chain_report(
-                &runtime_deployment.spec,
-                deployment.source_config.as_ref(),
-                Some(&source_revision),
-                runtime_deployment.local_image_id.as_deref(),
-                Utc::now().to_rfc3339(),
-            );
-            deployments
-                .record_supply_chain_report(deployment.id.as_str(), &report)
-                .await?;
-            runtime_deployment
+            (runtime_deployment, Some(source_revision))
         }
-        Ok(None) => RuntimeDeployment::from(&deployment),
+        Ok(None) => (
+            RuntimeDeployment::from(&deployment),
+            deployment.source_revision.clone(),
+        ),
         Err(error) => {
             tracing::warn!(deployment_id = %deployment.id, error = %error, "deployment source build failed");
             if deployments.cancel_requested(deployment.id.as_str()).await? {
@@ -385,6 +381,36 @@ where
         }
     };
     if deployments.cancel_requested(deployment.id.as_str()).await? {
+        return Ok(());
+    }
+    let policy = deployments.supply_chain_policy().await?;
+    let report = evaluate_supply_chain_report(
+        &runtime_deployment.spec,
+        deployment.source_config.as_ref(),
+        source_revision.as_deref(),
+        runtime_deployment.local_image_id.as_deref(),
+        policy.enforcement,
+        Utc::now().to_rfc3339(),
+    );
+    deployments
+        .record_supply_chain_report(deployment.id.as_str(), &report)
+        .await?;
+    if report.blocks_execution() {
+        let failure_reason = "supply-chain policy requires resolved provenance";
+        source_logs
+            .system("Supply-chain policy blocked runtime execution: provenance is unresolved")
+            .await?;
+        deployments
+            .transition(
+                deployment.id.as_str(),
+                DeploymentState::Failed,
+                None,
+                Some(failure_reason),
+            )
+            .await?;
+        publisher
+            .publish_events(deployments, deployment.id.as_str())
+            .await;
         return Ok(());
     }
     let predicted_runtime_ref = runtime.runtime_ref(&runtime_deployment);

--- a/crates/ignitify-control-plane/src/worker_resilience_tests.rs
+++ b/crates/ignitify-control-plane/src/worker_resilience_tests.rs
@@ -8,7 +8,9 @@ use ignitify_db::{
     Database, DatabaseConfig, DeploymentActor, DeploymentRecord, NewDeployment, NewServiceVariable,
     ServiceActor,
 };
-use ignitify_domain::{DeploymentState, ProjectInput, ServiceInput, SupplyChainCheckStatus};
+use ignitify_domain::{
+    DeploymentState, ProjectInput, ServiceInput, SupplyChainCheckStatus, SupplyChainEnforcement,
+};
 
 use super::{
     AgeCipher, Error, ImageRuntime, Ingress, RuntimeDeployment, RuntimeObservation, SourceBuild,
@@ -77,6 +79,96 @@ async fn queued_image_deployment() -> DeploymentContext {
             service.id.as_str(),
             NewDeployment {
                 idempotency_key: "resilience-deploy".to_owned(),
+                requested_by_user_id: actor_id.clone(),
+                spec: service.spec,
+                source_config: None,
+                deployment_destination_id: None,
+                source_revision: None,
+                supply_chain_report: None,
+                variables_ciphertext: cipher.encrypt(b"{}").unwrap(),
+            },
+        )
+        .await
+        .unwrap();
+    let ignitify_db::CreateDeploymentOutcome::Created(deployment) = deployment else {
+        panic!("deployment must be created");
+    };
+    let ignitify_db::DeploymentApprovalOutcome::Approved(deployment) = database
+        .deployments()
+        .approve(
+            DeploymentActor {
+                id: &actor_id,
+                is_admin: false,
+            },
+            deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("deployment must be approved for worker resilience tests");
+    };
+    DeploymentContext {
+        database,
+        actor_id,
+        deployment,
+        cipher,
+    }
+}
+
+async fn queued_unresolved_compose_deployment() -> DeploymentContext {
+    let database = Database::connect(&DatabaseConfig {
+        url: "sqlite::memory:".to_owned(),
+    })
+    .await
+    .unwrap();
+    let actor_id = database
+        .users()
+        .create("owner", "hash", ignitify_db::UserRole::User)
+        .await
+        .unwrap()
+        .id;
+    let project = database
+        .projects()
+        .create(&actor_id, ProjectInput::new("Resilience").unwrap())
+        .await
+        .unwrap();
+    let service = database
+        .services()
+        .create(
+            ServiceActor {
+                id: &actor_id,
+                is_admin: false,
+            },
+            project.id.as_str(),
+            ServiceInput::compose(
+                "web",
+                "services:\n  app:\n    image: nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "app",
+                Some(8080),
+                vec![],
+            )
+            .unwrap()
+            .configuration,
+            Vec::<NewServiceVariable>::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    let ignitify_db::ServiceMutationOutcome::Created(service) = service else {
+        panic!("service must be created");
+    };
+    let identity = age::x25519::Identity::generate().to_string();
+    let cipher = AgeCipher::from_identity(identity.expose_secret()).unwrap();
+    let deployment = database
+        .deployments()
+        .create(
+            DeploymentActor {
+                id: &actor_id,
+                is_admin: false,
+            },
+            service.id.as_str(),
+            NewDeployment {
+                idempotency_key: "unresolved-compose".to_owned(),
                 requested_by_user_id: actor_id.clone(),
                 spec: service.spec,
                 source_config: None,
@@ -415,6 +507,58 @@ async fn source_build_records_resolved_supply_chain_provenance_in_warning_mode()
         SupplyChainCheckStatus::Warning
     );
     assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn require_provenance_policy_blocks_unresolved_deployment_before_runtime_start() {
+    let context = queued_unresolved_compose_deployment().await;
+    context
+        .database
+        .deployments()
+        .update_supply_chain_enforcement(SupplyChainEnforcement::RequireProvenance)
+        .await
+        .unwrap();
+    let runtime = RecordingRuntime::new();
+
+    reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let deployment = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            context.deployment.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let report = deployment
+        .supply_chain_report
+        .expect("blocking report must be retained");
+
+    assert_eq!(deployment.state, DeploymentState::Failed);
+    assert_eq!(
+        deployment.failure_reason.as_deref(),
+        Some("supply-chain policy requires resolved provenance")
+    );
+    assert_eq!(
+        report.enforcement,
+        SupplyChainEnforcement::RequireProvenance
+    );
+    assert_eq!(report.provenance.status, SupplyChainCheckStatus::Warning);
+    assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test]

--- a/crates/ignitify-db/migrations/0039_supply_chain_policy.sql
+++ b/crates/ignitify-db/migrations/0039_supply_chain_policy.sql
@@ -1,0 +1,9 @@
+CREATE TABLE supply_chain_policy (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    enforcement TEXT NOT NULL DEFAULT 'warning'
+        CHECK (enforcement IN ('warning', 'require-provenance')),
+    updated_at TEXT NOT NULL
+);
+
+INSERT INTO supply_chain_policy (id, enforcement, updated_at)
+VALUES (1, 'warning', CURRENT_TIMESTAMP);

--- a/crates/ignitify-db/src/error.rs
+++ b/crates/ignitify-db/src/error.rs
@@ -34,6 +34,8 @@ pub enum DatabaseError {
     InvalidDeploymentState(String),
     #[error("invalid stored deployment supply-chain report: {0}")]
     InvalidDeploymentSupplyChainReport(String),
+    #[error("invalid stored supply-chain enforcement mode: {0}")]
+    InvalidSupplyChainEnforcement(String),
     #[error("invalid stored deployment approval status: {0}")]
     InvalidDeploymentApprovalStatus(String),
     #[error("domain hostname already exists")]

--- a/crates/ignitify-db/src/repositories/deployments.rs
+++ b/crates/ignitify-db/src/repositories/deployments.rs
@@ -17,6 +17,8 @@ mod deployment_reads;
 mod deployment_retry;
 #[path = "deployment_streams.rs"]
 mod deployment_streams;
+#[path = "supply_chain_policy.rs"]
+mod supply_chain_policy;
 
 use deployment_data::{
     DeploymentRow, DeploymentWithProjectRow, ProjectVariableRow, ServiceRow, VariableRow,

--- a/crates/ignitify-db/src/repositories/supply_chain_policy.rs
+++ b/crates/ignitify-db/src/repositories/supply_chain_policy.rs
@@ -1,0 +1,55 @@
+use chrono::Utc;
+use ignitify_domain::{SupplyChainEnforcement, SupplyChainPolicy};
+use sqlx::FromRow;
+
+use crate::{DatabaseError, Result};
+
+use super::DeploymentsRepository;
+
+impl DeploymentsRepository {
+    pub async fn supply_chain_policy(&self) -> Result<SupplyChainPolicy> {
+        let row = sqlx::query_as::<_, SupplyChainPolicyRow>(
+            "SELECT enforcement, updated_at FROM supply_chain_policy WHERE id = 1",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        row.into_policy()
+    }
+
+    pub async fn update_supply_chain_enforcement(
+        &self,
+        enforcement: SupplyChainEnforcement,
+    ) -> Result<SupplyChainPolicy> {
+        let updated_at = Utc::now().to_rfc3339();
+        sqlx::query(
+            "UPDATE supply_chain_policy
+             SET enforcement = ?, updated_at = ?
+             WHERE id = 1",
+        )
+        .bind(enforcement.as_str())
+        .bind(updated_at)
+        .execute(&self.pool)
+        .await?;
+        self.supply_chain_policy().await
+    }
+}
+
+#[derive(FromRow)]
+struct SupplyChainPolicyRow {
+    enforcement: String,
+    updated_at: String,
+}
+
+impl SupplyChainPolicyRow {
+    fn into_policy(self) -> Result<SupplyChainPolicy> {
+        let enforcement = self
+            .enforcement
+            .as_str()
+            .try_into()
+            .map_err(|_| DatabaseError::InvalidSupplyChainEnforcement(self.enforcement))?;
+        Ok(SupplyChainPolicy {
+            enforcement,
+            updated_at: self.updated_at,
+        })
+    }
+}

--- a/crates/ignitify-db/src/tests.rs
+++ b/crates/ignitify-db/src/tests.rs
@@ -90,6 +90,29 @@ async fn migrations_create_auth_storage() {
     .await
     .unwrap();
     assert_eq!(count, 1, "uptime check history must be durable");
+    let policy = database.deployments().supply_chain_policy().await.unwrap();
+    assert_eq!(
+        policy.enforcement,
+        ignitify_domain::SupplyChainEnforcement::Warning
+    );
+}
+
+#[tokio::test]
+async fn supply_chain_policy_persists_the_operator_enforcement_mode() {
+    let database = database().await;
+
+    let updated = database
+        .deployments()
+        .update_supply_chain_enforcement(ignitify_domain::SupplyChainEnforcement::RequireProvenance)
+        .await
+        .unwrap();
+    let reloaded = database.deployments().supply_chain_policy().await.unwrap();
+
+    assert_eq!(
+        updated.enforcement,
+        ignitify_domain::SupplyChainEnforcement::RequireProvenance
+    );
+    assert_eq!(reloaded, updated);
 }
 
 #[tokio::test]
@@ -1302,6 +1325,7 @@ async fn deployment_repository_enforces_idempotency_active_conflict_and_immutabl
         None,
         None,
         None,
+        ignitify_domain::SupplyChainEnforcement::Warning,
         "2026-08-14T00:00:00Z".to_owned(),
     );
     let first = database

--- a/crates/ignitify-domain/src/lib.rs
+++ b/crates/ignitify-domain/src/lib.rs
@@ -12,8 +12,8 @@ mod supply_chain;
 pub use deployment_approval::{DeploymentApproval, ProductionApprovalStatus};
 pub use dns::{DnsRecord, DnsRecordTarget, DnsRecordType, DnsVerificationStatus};
 pub use supply_chain::{
-    SupplyChainCheck, SupplyChainCheckStatus, SupplyChainEnforcement, SupplyChainReport,
-    evaluate_supply_chain_report,
+    SupplyChainCheck, SupplyChainCheckStatus, SupplyChainEnforcement, SupplyChainPolicy,
+    SupplyChainReport, evaluate_supply_chain_report,
 };
 
 macro_rules! uuid_id {
@@ -673,6 +673,8 @@ pub enum InputError {
     InvalidDnsRecordTarget,
     #[error("invalid DNS verification status")]
     InvalidDnsVerificationStatus,
+    #[error("invalid supply-chain enforcement mode")]
+    InvalidSupplyChainEnforcement,
 }
 
 pub type Result<T> = std::result::Result<T, InputError>;

--- a/crates/ignitify-domain/src/supply_chain.rs
+++ b/crates/ignitify-domain/src/supply_chain.rs
@@ -10,9 +10,37 @@ pub enum SupplyChainCheckStatus {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum SupplyChainEnforcement {
     Warning,
+    RequireProvenance,
+}
+
+impl SupplyChainEnforcement {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Warning => "warning",
+            Self::RequireProvenance => "require-provenance",
+        }
+    }
+}
+
+impl TryFrom<&str> for SupplyChainEnforcement {
+    type Error = crate::InputError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "warning" => Ok(Self::Warning),
+            "require-provenance" => Ok(Self::RequireProvenance),
+            _ => Err(crate::InputError::InvalidSupplyChainEnforcement),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupplyChainPolicy {
+    pub enforcement: SupplyChainEnforcement,
+    pub updated_at: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -33,6 +61,13 @@ pub struct SupplyChainReport {
     pub evaluated_at: String,
 }
 
+impl SupplyChainReport {
+    pub fn blocks_execution(&self) -> bool {
+        self.enforcement == SupplyChainEnforcement::RequireProvenance
+            && self.provenance.status == SupplyChainCheckStatus::Warning
+    }
+}
+
 /// Produces an informational policy snapshot from the identities Ignitify has
 /// actually resolved. Missing external evidence is a warning, never a pass.
 pub fn evaluate_supply_chain_report(
@@ -40,6 +75,7 @@ pub fn evaluate_supply_chain_report(
     source_config: Option<&ServiceSourceConfig>,
     source_revision: Option<&str>,
     local_image_id: Option<&str>,
+    enforcement: SupplyChainEnforcement,
     evaluated_at: String,
 ) -> SupplyChainReport {
     let has_resolved_build_identity = source_revision.is_some() && local_image_id.is_some();
@@ -86,7 +122,7 @@ pub fn evaluate_supply_chain_report(
     };
 
     SupplyChainReport {
-        enforcement: SupplyChainEnforcement::Warning,
+        enforcement,
         status: SupplyChainCheckStatus::Warning,
         provenance,
         sbom,
@@ -97,7 +133,7 @@ pub fn evaluate_supply_chain_report(
 
 #[cfg(test)]
 mod tests {
-    use super::{SupplyChainCheckStatus, evaluate_supply_chain_report};
+    use super::{SupplyChainCheckStatus, SupplyChainEnforcement, evaluate_supply_chain_report};
     use crate::ServiceSpec;
 
     const DIGEST: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -107,8 +143,14 @@ mod tests {
         let spec = ServiceSpec::image(format!("registry.example/app@{DIGEST}"), Some(8080), None)
             .expect("digest image is valid");
 
-        let report =
-            evaluate_supply_chain_report(&spec, None, None, None, "2026-08-14T00:00:00Z".into());
+        let report = evaluate_supply_chain_report(
+            &spec,
+            None,
+            None,
+            None,
+            SupplyChainEnforcement::Warning,
+            "2026-08-14T00:00:00Z".into(),
+        );
 
         assert_eq!(report.enforcement, super::SupplyChainEnforcement::Warning);
         assert_eq!(report.status, SupplyChainCheckStatus::Warning);
@@ -130,6 +172,7 @@ mod tests {
             None,
             Some(&"a".repeat(40)),
             None,
+            SupplyChainEnforcement::Warning,
             "2026-08-14T00:00:00Z".into(),
         );
         let resolved = evaluate_supply_chain_report(
@@ -137,6 +180,7 @@ mod tests {
             None,
             Some(&"a".repeat(40)),
             Some(DIGEST),
+            SupplyChainEnforcement::Warning,
             "2026-08-14T00:01:00Z".into(),
         );
 
@@ -170,9 +214,35 @@ mod tests {
             Some(&source_config),
             None,
             None,
+            SupplyChainEnforcement::Warning,
             "2026-08-14T00:00:00Z".into(),
         );
 
         assert_eq!(report.provenance.status, SupplyChainCheckStatus::Warning);
+    }
+
+    #[test]
+    fn require_provenance_blocks_only_an_unresolved_provenance_check() {
+        let spec =
+            ServiceSpec::compose("services: {}", "app", Some(8080)).expect("compose spec is valid");
+        let blocked = evaluate_supply_chain_report(
+            &spec,
+            None,
+            None,
+            None,
+            SupplyChainEnforcement::RequireProvenance,
+            "2026-08-14T00:00:00Z".into(),
+        );
+        let permitted = evaluate_supply_chain_report(
+            &spec,
+            None,
+            Some(&"a".repeat(40)),
+            Some(DIGEST),
+            SupplyChainEnforcement::RequireProvenance,
+            "2026-08-14T00:00:00Z".into(),
+        );
+
+        assert!(blocked.blocks_execution());
+        assert!(!permitted.blocks_execution());
     }
 }

--- a/docs/concepts/deployment-lifecycle.md
+++ b/docs/concepts/deployment-lifecycle.md
@@ -89,11 +89,20 @@ deployments pass provenance only when their immutable image digest is present;
 source builds replace the initial report after both the resolved source revision
 and built image digest are known.
 
-The current enforcement mode is `warning`: reports never block a deployment.
-An unavailable SBOM or vulnerability scan is reported as a warning with a
-remediation action, never as a pass. Release SBOMs describe the Ignitify
-control-plane artifact; attach a separate CycloneDX or SPDX SBOM for each
-application image before a future blocking policy is enabled.
+Platform operators configure the delivery policy as either `warning` (the
+default) or `require-provenance`. The worker evaluates the current policy after
+source resolution and before `runtime.start`. `require-provenance` blocks only
+an unresolved provenance check: a direct image needs its immutable digest, and
+a source build needs both its resolved revision and built image digest. The
+blocked snapshot, report, failure event, and system log remain available for
+review; terminal deployments are never re-evaluated after a policy change.
+
+An unavailable SBOM or vulnerability scan remains a warning with a remediation
+action, never a pass or a blocking condition. Ignitify has no application-image
+SBOM or scan attachment/verification boundary yet. Release SBOMs describe the
+Ignitify control-plane artifact; attach a separate CycloneDX or SPDX SBOM for
+each application image until such evidence can be verified by the control
+plane.
 
 ## Incident correlation
 

--- a/docs/id/concepts/deployment-lifecycle.md
+++ b/docs/id/concepts/deployment-lifecycle.md
@@ -90,11 +90,21 @@ Deployment image langsung hanya lulus provenance ketika image digest immutable
 tersedia; source build mengganti laporan awal setelah source revision dan built
 image digest sudah diketahui.
 
-Mode enforcement saat ini adalah `warning`: laporan tidak pernah memblokir
-deployment. SBOM atau vulnerability scan yang belum tersedia dilaporkan sebagai
-peringatan dengan tindakan remediation, bukan sebagai pass. SBOM release
-menjelaskan artefak control plane Ignitify; lampirkan SBOM CycloneDX atau SPDX
-terpisah untuk setiap application image sebelum kebijakan blocking diaktifkan.
+Operator platform mengatur kebijakan delivery menjadi `warning` (default) atau
+`require-provenance`. Worker mengevaluasi kebijakan saat ini setelah source
+resolution dan sebelum `runtime.start`. `require-provenance` hanya memblokir
+pemeriksaan provenance yang belum terselesaikan: image langsung membutuhkan
+digest immutable, sedangkan source build membutuhkan resolved revision dan
+built image digest. Snapshot yang diblokir, laporan, event gagal, dan log
+sistem tetap tersedia untuk ditinjau; deployment terminal tidak dievaluasi
+ulang setelah kebijakan berubah.
+
+SBOM atau vulnerability scan yang belum tersedia tetap berupa peringatan dengan
+tindakan remediation, bukan pass atau kondisi pemblokiran. Ignitify belum
+memiliki boundary attachment/verifikasi SBOM atau scan application-image.
+SBOM release menjelaskan artefak control plane Ignitify; lampirkan SBOM
+CycloneDX atau SPDX terpisah untuk setiap application image sampai bukti itu
+dapat diverifikasi oleh control plane.
 
 ## Korelasi insiden
 

--- a/docs/id/reference/api.md
+++ b/docs/id/reference/api.md
@@ -13,10 +13,10 @@ Base URL local: `http://127.0.0.1:5656`. Semua route control plane berada di baw
   ke event serta log. Nilai ini adalah metadata aman untuk insiden, bukan
   kredensial.
 - Respons deployment juga menyertakan `supply_chain_report` opsional dengan
-  pemeriksaan `provenance`, `sbom`, dan `vulnerabilities`. `enforcement` saat
-  ini adalah `warning`; SBOM atau scan eksternal yang belum ada tetap merupakan
-  peringatan dengan string remediation dan tidak pernah dianggap pemeriksaan
-  yang berhasil.
+  pemeriksaan `provenance`, `sbom`, dan `vulnerabilities`. `enforcement` adalah
+  evaluasi kebijakan yang disimpan (`warning` atau `require-provenance`); SBOM
+  atau scan eksternal yang belum ada tetap merupakan peringatan dengan string
+  remediation dan tidak pernah dianggap pemeriksaan yang berhasil.
 - Identifier resource adalah UUID. Gunakan idempotency key ketika membuat deployment.
 
 ## Autentikasi
@@ -120,6 +120,20 @@ Environment project memakai bentuk berikut. Untuk mempertahankan secret yang sud
 | `GET`         | `/api/v1/deployments/{deployment_id}/logs`     | SSE line log.                                   |
 
 Submit deployment membutuhkan header idempotency key sesuai kontrak client. Request produksi mengembalikan objek `approval` dan tetap pending sampai owner project atau operator platform menyetujuinya. Respons menampilkan bukti source/image immutable di `source_identity` saat sudah diketahui. Untuk melanjutkan SSE, kirim `Last-Event-ID` atau parameter query `after=<sequence>`. Stream mengirim event `snapshot` jika cursor lebih lama dari data yang masih tersedia, heartbeat sekitar 15 detik, dan event `log` untuk stream log.
+
+## Kebijakan delivery
+
+| Method | Path                                      | Keterangan                                      |
+| ------ | ----------------------------------------- | ----------------------------------------------- |
+| `GET`  | `/api/v1/settings/supply-chain-policy`    | Baca mode enforcement delivery platform.        |
+| `PUT`  | `/api/v1/settings/supply-chain-policy`    | Ubah mode enforcement delivery platform.        |
+
+Kedua route membutuhkan akses operator platform; `PUT` juga membutuhkan
+`X-Ignitify-Request: 1` dan origin tepercaya. Body-nya adalah
+`{ "enforcement": "warning" | "require-provenance" }`. Mode kedua hanya
+memblokir eksekusi runtime jika provenance tidak dapat diselesaikan sebelum
+start. Mode ini tidak menganggap SBOM atau bukti vulnerability eksternal yang
+hilang sebagai pemeriksaan berhasil ataupun sebagai blok.
 
 ## Monitoring uptime
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -13,9 +13,10 @@ Local base URL: `http://127.0.0.1:5656`. All control plane routes are under `/ap
   ID to event and log records. These values are safe incident metadata, not
   credentials.
 - Deployment responses also include an optional `supply_chain_report` with
-  `provenance`, `sbom`, and `vulnerabilities` checks. The current `enforcement`
-  is `warning`; a missing external SBOM or scan remains a warning with a
-  remediation string and never represents a successful check.
+  `provenance`, `sbom`, and `vulnerabilities` checks. Its `enforcement` is the
+  retained policy evaluation (`warning` or `require-provenance`); a missing
+  external SBOM or scan remains a warning with a remediation string and never
+  represents a successful check.
 - Resource identifiers are UUIDs. Use an idempotency key when creating a deployment.
 
 ## Authentication
@@ -119,6 +120,20 @@ Project environments use this shape. To keep an existing secret, send `value: nu
 | `GET`         | `/api/v1/deployments/{deployment_id}/logs`     | SSE log lines.                                   |
 
 Deployment submission requires an idempotency key header according to the client contract. Production requests return an `approval` object and remain pending until a project owner or platform operator approves them. Responses expose immutable source/image evidence under `source_identity` when it is known. To resume SSE, send `Last-Event-ID` or the `after=<sequence>` query parameter. Streams send a `snapshot` event when the cursor is older than the retained data, a heartbeat about every 15 seconds, and `log` events on the log stream.
+
+## Delivery policy
+
+| Method     | Path                                        | Description                                      |
+| ---------- | ------------------------------------------- | ------------------------------------------------ |
+| `GET`      | `/api/v1/settings/supply-chain-policy`      | Read the platform delivery enforcement mode.     |
+| `PUT`      | `/api/v1/settings/supply-chain-policy`      | Update the platform delivery enforcement mode.   |
+
+Both routes require platform operator access; `PUT` also requires
+`X-Ignitify-Request: 1` and a trusted origin. The body is
+`{ "enforcement": "warning" | "require-provenance" }`. The latter blocks
+runtime execution only when provenance cannot be resolved before start. It does
+not treat missing external SBOM or vulnerability evidence as a successful check
+or a block.
 
 ## Uptime monitoring
 

--- a/frontend/src/components/project/DeploymentSupplyChainPanel.vue
+++ b/frontend/src/components/project/DeploymentSupplyChainPanel.vue
@@ -10,6 +10,11 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const enforcementDescription = computed(() =>
+  props.report?.enforcement === "require-provenance"
+    ? t("supplyChain.requireProvenanceMode")
+    : t("supplyChain.warningMode"),
+);
 const checks = computed(() =>
   props.report
     ? [
@@ -40,7 +45,7 @@ function statusLabel(check: Pick<SupplyChainCheck, "status">) {
     <div class="flex flex-wrap items-start justify-between gap-3 px-1">
       <div>
         <p class="ui-label">{{ t("supplyChain.title") }}</p>
-        <p class="mt-1 text-xs text-muted-foreground">{{ t("supplyChain.warningMode") }}</p>
+        <p class="mt-1 text-xs text-muted-foreground">{{ enforcementDescription }}</p>
       </div>
       <Badge
         variant="outline"

--- a/frontend/src/components/settings/SupplyChainPolicySettings.spec.ts
+++ b/frontend/src/components/settings/SupplyChainPolicySettings.spec.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, nextTick } from "vue";
+import i18n from "@/i18n";
+
+const mocks = vi.hoisted(() => ({
+  getPolicy: vi.fn(),
+  updatePolicy: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  apiGetSupplyChainPolicy: mocks.getPolicy,
+  apiUpdateSupplyChainPolicy: mocks.updatePolicy,
+}));
+
+const mountedApps: Array<{ unmount: () => void }> = [];
+
+async function settle() {
+  for (let index = 0; index < 3; index += 1) {
+    await Promise.resolve();
+    await nextTick();
+  }
+}
+
+afterEach(() => {
+  for (const app of mountedApps) app.unmount();
+  mountedApps.length = 0;
+  document.body.replaceChildren();
+  mocks.getPolicy.mockReset();
+  mocks.updatePolicy.mockReset();
+});
+
+describe("SupplyChainPolicySettings", () => {
+  beforeEach(() => {
+    mocks.getPolicy.mockResolvedValue({
+      success: true,
+      data: {
+        enforcement: "warning",
+        updated_at: "2026-08-14T00:00:00Z",
+      },
+    });
+  });
+
+  it("loads the operator policy and explains the compatible default", async () => {
+    const component = (await import("./SupplyChainPolicySettings.vue")).default;
+    const host = document.createElement("div");
+    document.body.append(host);
+    const app = createApp(component);
+    app.use(i18n);
+    app.mount(host);
+    mountedApps.push(app);
+    await settle();
+
+    expect(mocks.getPolicy).toHaveBeenCalledTimes(1);
+    expect(host.textContent).toContain("Deployment provenance");
+    expect(host.textContent).toContain("Warning only");
+    expect(host.textContent).toContain("runtime execution continues");
+    expect(host.textContent).toContain("Updated 2026-08-14T00:00:00Z");
+  });
+});

--- a/frontend/src/components/settings/SupplyChainPolicySettings.vue
+++ b/frontend/src/components/settings/SupplyChainPolicySettings.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { ShieldAlert } from "@lucide/vue";
+import { computed, onMounted, shallowRef } from "vue";
+import { useI18n } from "vue-i18n";
+import { toast } from "vue-sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { apiGetSupplyChainPolicy, apiUpdateSupplyChainPolicy } from "@/lib/api";
+import type { SupplyChainEnforcement } from "@/lib/types";
+
+const { t } = useI18n();
+const enforcement = shallowRef<SupplyChainEnforcement>("warning");
+const savedEnforcement = shallowRef<SupplyChainEnforcement | null>(null);
+const updatedAt = shallowRef("");
+const state = shallowRef<"loading" | "idle" | "saving" | "error">("loading");
+const requestError = shallowRef("");
+
+const isDirty = computed(
+  () => savedEnforcement.value !== null && enforcement.value !== savedEnforcement.value,
+);
+const canSave = computed(
+  () => state.value !== "loading" && state.value !== "saving" && isDirty.value,
+);
+
+function selectEnforcement(value: string) {
+  if (value === "warning" || value === "require-provenance") {
+    enforcement.value = value;
+    requestError.value = "";
+  }
+}
+
+async function loadPolicy() {
+  state.value = "loading";
+  requestError.value = "";
+  const result = await apiGetSupplyChainPolicy();
+  if (!result.success) {
+    requestError.value = result.error ?? t("supplyChainSettings.loadError");
+    state.value = "error";
+    return;
+  }
+  enforcement.value = result.data.enforcement;
+  savedEnforcement.value = result.data.enforcement;
+  updatedAt.value = result.data.updated_at;
+  state.value = "idle";
+}
+
+async function savePolicy() {
+  if (!canSave.value) return;
+  state.value = "saving";
+  requestError.value = "";
+  const result = await apiUpdateSupplyChainPolicy(enforcement.value);
+  if (!result.success) {
+    requestError.value = result.error ?? t("supplyChainSettings.saveError");
+    state.value = "error";
+    return;
+  }
+  savedEnforcement.value = result.data.enforcement;
+  updatedAt.value = result.data.updated_at;
+  state.value = "idle";
+  toast.success(t("supplyChainSettings.saved"));
+}
+
+onMounted(loadPolicy);
+</script>
+
+<template>
+  <section class="app-surface" aria-labelledby="supply-chain-policy-heading">
+    <header class="app-panel-header flex items-start gap-3 px-5 py-4">
+      <span
+        class="grid size-8 shrink-0 place-items-center rounded-[6px] border border-border bg-muted text-muted-foreground"
+      >
+        <ShieldAlert class="size-4" :stroke-width="1.5" />
+      </span>
+      <div>
+        <p class="ui-label">{{ t("supplyChainSettings.eyebrow") }}</p>
+        <h2 id="supply-chain-policy-heading" class="mt-1.5 text-base font-medium">
+          {{ t("supplyChainSettings.title") }}
+        </h2>
+        <p class="mt-1.5 max-w-[62ch] text-xs leading-5 text-muted-foreground">
+          {{ t("supplyChainSettings.description") }}
+        </p>
+      </div>
+    </header>
+
+    <div class="grid gap-2 border-t border-border px-5 py-4 sm:max-w-xl">
+      <label for="supply-chain-enforcement" class="text-xs font-medium">
+        {{ t("supplyChainSettings.enforcement") }}
+      </label>
+      <Select :model-value="enforcement" @update:model-value="selectEnforcement(String($event))">
+        <SelectTrigger id="supply-chain-enforcement" class="rounded-[3px] text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="warning">{{ t("supplyChainSettings.warning") }}</SelectItem>
+          <SelectItem value="require-provenance">
+            {{ t("supplyChainSettings.requireProvenance") }}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+      <p class="text-[11px] leading-4 text-muted-foreground">
+        {{
+          enforcement === "require-provenance"
+            ? t("supplyChainSettings.requireProvenanceDescription")
+            : t("supplyChainSettings.warningDescription")
+        }}
+      </p>
+      <p v-if="updatedAt" class="font-mono text-[10px] text-muted-foreground">
+        {{ t("supplyChainSettings.updated", { time: updatedAt }) }}
+      </p>
+      <p v-if="requestError" class="text-[11px] text-destructive" role="alert">
+        {{ requestError }}
+      </p>
+      <div class="mt-2 flex items-center gap-3">
+        <Button size="sm" type="button" :disabled="!canSave" @click="savePolicy">
+          {{ t("supplyChainSettings.save") }}
+        </Button>
+        <span v-if="state === 'loading'" class="text-[11px] text-muted-foreground">
+          {{ t("supplyChainSettings.loading") }}
+        </span>
+      </div>
+    </div>
+  </section>
+</template>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -175,11 +175,31 @@ export default {
   supplyChain: {
     title: "Supply-chain policy",
     warningMode: "Warnings do not block this deployment.",
+    requireProvenanceMode: "Unresolved provenance blocks runtime execution.",
     pass: "Pass",
     warning: "Warning",
     provenance: "Provenance",
     sbom: "SBOM",
     vulnerabilities: "Vulnerabilities",
+  },
+  supplyChainSettings: {
+    tab: "Delivery policy",
+    eyebrow: "Secure delivery",
+    title: "Deployment provenance",
+    description: "Choose how Ignitify handles the provenance signal before a runtime is started.",
+    enforcement: "Enforcement mode",
+    warning: "Warning only",
+    requireProvenance: "Require resolved provenance",
+    warningDescription:
+      "Deployment reports retain unresolved provenance as a warning and runtime execution continues.",
+    requireProvenanceDescription:
+      "Runtime execution stops when Ignitify cannot retain both a source revision and an image digest, or an immutable direct-image digest.",
+    updated: "Updated {time}",
+    save: "Save delivery policy",
+    saved: "Delivery policy saved",
+    loading: "Loading delivery policy",
+    loadError: "Unable to load delivery policy.",
+    saveError: "Unable to save delivery policy.",
   },
   deploymentApproval: {
     title: "Production approval",

--- a/frontend/src/i18n/locales/id.ts
+++ b/frontend/src/i18n/locales/id.ts
@@ -174,11 +174,31 @@ export default {
   supplyChain: {
     title: "Kebijakan rantai pasok",
     warningMode: "Peringatan tidak memblokir deployment ini.",
+    requireProvenanceMode: "Provenance yang belum terselesaikan memblokir eksekusi runtime.",
     pass: "Lulus",
     warning: "Peringatan",
     provenance: "Provenance",
     sbom: "SBOM",
     vulnerabilities: "Kerentanan",
+  },
+  supplyChainSettings: {
+    tab: "Kebijakan delivery",
+    eyebrow: "Delivery aman",
+    title: "Provenance deployment",
+    description: "Pilih cara Ignitify menangani sinyal provenance sebelum runtime dimulai.",
+    enforcement: "Mode enforcement",
+    warning: "Peringatan saja",
+    requireProvenance: "Wajibkan provenance terselesaikan",
+    warningDescription:
+      "Laporan deployment menyimpan provenance yang belum terselesaikan sebagai peringatan dan eksekusi runtime dilanjutkan.",
+    requireProvenanceDescription:
+      "Eksekusi runtime berhenti saat Ignitify tidak dapat menyimpan source revision serta image digest, atau digest image langsung yang immutable.",
+    updated: "Diperbarui {time}",
+    save: "Simpan kebijakan delivery",
+    saved: "Kebijakan delivery disimpan",
+    loading: "Memuat kebijakan delivery",
+    loadError: "Tidak dapat memuat kebijakan delivery.",
+    saveError: "Tidak dapat menyimpan kebijakan delivery.",
   },
   deploymentApproval: {
     title: "Persetujuan produksi",

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -1,5 +1,6 @@
 import type { ApiResult } from "./core";
 import { apiFetch } from "./core";
+import type { SupplyChainEnforcement } from "@/lib/types";
 
 export type ServerCertificateProvider = "none" | "lets-encrypt" | "custom";
 
@@ -58,6 +59,11 @@ export interface InfrastructureSettingsInput {
   concurrent_builds: number;
 }
 
+export interface SupplyChainPolicyResponse {
+  enforcement: SupplyChainEnforcement;
+  updated_at: string;
+}
+
 const endpoint = "/settings/infrastructure";
 
 export function apiGetInfrastructureSettings(): Promise<ApiResult<InfrastructureSettingsResponse>> {
@@ -70,6 +76,19 @@ export function apiUpdateInfrastructureSettings(
   return apiFetch<InfrastructureSettingsResponse>(endpoint, {
     method: "PATCH",
     body: JSON.stringify(input),
+  });
+}
+
+export function apiGetSupplyChainPolicy(): Promise<ApiResult<SupplyChainPolicyResponse>> {
+  return apiFetch<SupplyChainPolicyResponse>("/settings/supply-chain-policy");
+}
+
+export function apiUpdateSupplyChainPolicy(
+  enforcement: SupplyChainEnforcement,
+): Promise<ApiResult<SupplyChainPolicyResponse>> {
+  return apiFetch<SupplyChainPolicyResponse>("/settings/supply-chain-policy", {
+    method: "PUT",
+    body: JSON.stringify({ enforcement }),
   });
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -234,6 +234,7 @@ export interface DeploymentLog {
 }
 
 export type SupplyChainCheckStatus = "pass" | "warning";
+export type SupplyChainEnforcement = "warning" | "require-provenance";
 
 export interface SupplyChainCheck {
   status: SupplyChainCheckStatus;
@@ -242,7 +243,7 @@ export interface SupplyChainCheck {
 }
 
 export interface SupplyChainReport {
-  enforcement: "warning";
+  enforcement: SupplyChainEnforcement;
   status: SupplyChainCheckStatus;
   provenance: SupplyChainCheck;
   sbom: SupplyChainCheck;

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -6,6 +6,7 @@ import {
   RefreshCw,
   RotateCcw,
   Save,
+  ShieldCheck,
 } from "@lucide/vue";
 import { computed, onMounted, reactive, shallowRef } from "vue";
 import { useI18n } from "vue-i18n";
@@ -19,6 +20,7 @@ import ControlPlaneIngressSettings from "@/components/settings/ControlPlaneIngre
 import IngressFallbackSettings from "@/components/settings/IngressFallbackSettings.vue";
 import InfrastructureHealth from "@/components/settings/InfrastructureHealth.vue";
 import OperationalHealthSummary from "@/components/settings/OperationalHealthSummary.vue";
+import SupplyChainPolicySettings from "@/components/settings/SupplyChainPolicySettings.vue";
 import type {
   CertificateProvider,
   CustomCertificateSummary,
@@ -54,7 +56,7 @@ interface SettingsDraft {
   concurrentBuilds: number;
 }
 
-type SettingsSection = "overview" | "ingress" | "backup";
+type SettingsSection = "overview" | "ingress" | "delivery" | "backup";
 
 const defaults: SettingsDraft = {
   controlPlaneDomain: "",
@@ -281,13 +283,15 @@ const sectionDescription = computed(() => {
       return "Configure managed routing, TLS policy, and the unmatched-hostname page.";
     case "backup":
       return "Configure durable control-plane backup storage and recovery access.";
+    case "delivery":
+      return t("supplyChainSettings.description");
     default:
       return "Review host readiness, runtime defaults, and build capacity.";
   }
 });
 
 function selectSection(value: string) {
-  if (value === "overview" || value === "ingress" || value === "backup") {
+  if (value === "overview" || value === "ingress" || value === "delivery" || value === "backup") {
     activeSection.value = value;
   }
 }
@@ -502,6 +506,10 @@ onMounted(loadSettings);
           <Network class="size-3.5" :stroke-width="1.5" />
           Ingress &amp; TLS
         </TabsTrigger>
+        <TabsTrigger value="delivery" class="min-w-max px-3 text-xs">
+          <ShieldCheck class="size-3.5" :stroke-width="1.5" />
+          {{ t("supplyChainSettings.tab") }}
+        </TabsTrigger>
         <TabsTrigger value="backup" class="min-w-max px-3 text-xs">
           <HardDriveDownload class="size-3.5" :stroke-width="1.5" />
           Backup
@@ -607,6 +615,10 @@ onMounted(loadSettings);
             <span class="shrink-0 font-mono">Admin only</span>
           </footer>
         </form>
+      </TabsContent>
+
+      <TabsContent value="delivery" class="mt-4">
+        <SupplyChainPolicySettings />
       </TabsContent>
 
       <TabsContent value="backup" class="mt-4">

--- a/infra/operations/runbooks.md
+++ b/infra/operations/runbooks.md
@@ -71,9 +71,14 @@ source build, runtime start/health, or ingress synchronization.
 - Source build failure: verify the provider/repository and immutable source
   revision, then retry after the provider or builder is healthy.
 - Supply-chain warning: read the deployment's provenance, SBOM, and
-  vulnerability remediation before promoting the result. A warning is
-  informational in the current policy mode; do not represent it as a passed
-  scan or remove the deployment record to hide it.
+  vulnerability remediation before promoting the result. A warning mode is
+  informational; do not represent it as a passed scan or remove the deployment
+  record to hide it.
+- Supply-chain policy block: inspect the retained report and system log. Under
+  `require-provenance`, record an immutable direct-image digest or rebuild until
+  both the source revision and built image digest are retained. Do not downgrade
+  the policy merely to discard the failed snapshot; submit a new deployment
+  after the evidence is resolved.
 - Pending production approval: inspect the immutable source/image identity and
   supply-chain warning first. A project owner or platform operator can approve
   the exact snapshot; otherwise cancel it. Do not bypass approval by changing

--- a/roadmap.md
+++ b/roadmap.md
@@ -210,19 +210,23 @@ Target: days 61-90.
 
 - [x] Production deployments have an auditable source/image identity and an
   approval trail.
-- [ ] Supply-chain signals are visible before deployment and can be governed by
+- [x] Supply-chain signals are visible before deployment and can be governed by
   policy.
 - [x] Historical monitoring provides enough context to investigate regressions and
   alert fatigue.
 
 Evidence: migration `0036_deployment_supply_chain_reports.sql` stores an
-optional per-deployment report. Immutable direct-image digests and resolved
-source-build revision/image pairs pass the provenance check. Application-image
-SBOM and vulnerability evidence that is not attached remains an explicit
-warning with remediation; the worker does not block a deployment. The API and
-service deployment panel expose the report before runtime execution advances,
-and domain/database/control-plane/API/frontend regression coverage verifies
-the warning-mode contract.
+optional per-deployment report, and migration
+`0039_supply_chain_policy.sql` stores the audited platform policy. Immutable
+direct-image digests and resolved source-build revision/image pairs pass the
+provenance check. Operators can retain the compatible `warning` default or use
+`require-provenance`, which the worker re-evaluates after source resolution and
+before runtime execution; an unresolved provenance signal fails the snapshot
+without calling the runtime. Application-image SBOM and vulnerability evidence
+that is not attached remains an explicit warning with remediation, not a false
+pass or block. The API, delivery-policy UI, and service deployment panel expose
+the policy/report, with domain/database/control-plane/API/frontend regression
+coverage for warning and enforcement behavior.
 
 Evidence: migration `0037_deployment_production_approvals.sql` records pending
 and approved production promotion states. Owners and platform operators must


### PR DESCRIPTION
Adds an audited operator policy with warning and require-provenance modes. The worker re-evaluates policy after source resolution and fails unresolved provenance before runtime start. Includes migration, API/OpenAPI, settings UI, bilingual docs, runbook, roadmap completion, and regression coverage.