### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-api"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "age",
  "argon2",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-auth"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-backup-s3"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "hmac",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-control-plane"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "age",
  "chrono",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-core"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "age",
  "axum",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-db"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "ignitify-domain",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-dns"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "hickory-resolver",
  "ignitify-control-plane",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-domain"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-ingress-traefik"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-db",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-monitoring"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "ignitify-db",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-notifications"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "ignitify-control-plane",
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-compose"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-docker"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-remote"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "ignitify-control-plane",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-source-git"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-terminal"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "portable-pty",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitify-frontend",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- synchronize Rust workspace, lockfile, and frontend package metadata to 0.2.0
- prepare the next non-breaking feature release after v0.1.3

## Validation
- pnpm run typecheck
- cargo check --workspace