### PR TITLE
fix: stop healthy Compose deployments

### DIFF
--- a/crates/ignitify-control-plane/src/worker_resilience_tests.rs
+++ b/crates/ignitify-control-plane/src/worker_resilience_tests.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use age::secrecy::ExposeSecret;
 use ignitify_db::{
     Database, DatabaseConfig, DeploymentActor, DeploymentRecord, NewDeployment, NewServiceVariable,
-    ServiceActor,
+    ProjectActor, ProjectRemoveOutcome, ServiceActor, ServiceMutationOutcome,
 };
 use ignitify_domain::{
     DeploymentState, ProjectInput, ServiceInput, SupplyChainCheckStatus, SupplyChainEnforcement,
@@ -16,11 +16,12 @@ use super::{
     AgeCipher, Error, ImageRuntime, Ingress, RuntimeDeployment, RuntimeObservation, SourceBuild,
     StreamPublisher, reconcile_once, reconcile_once_with_source,
 };
-use crate::{IngressRoute, RuntimeLog, SourceBuildOutput};
+use crate::{ControlHandle, DeploymentSubmission, IngressRoute, RuntimeLog, SourceBuildOutput};
 
 struct DeploymentContext {
     database: Database,
     actor_id: String,
+    project_id: String,
     deployment: DeploymentRecord,
     cipher: AgeCipher,
 }
@@ -110,6 +111,7 @@ async fn queued_image_deployment() -> DeploymentContext {
     DeploymentContext {
         database,
         actor_id,
+        project_id: project.id.to_string(),
         deployment,
         cipher,
     }
@@ -200,6 +202,7 @@ async fn queued_unresolved_compose_deployment() -> DeploymentContext {
     DeploymentContext {
         database,
         actor_id,
+        project_id: project.id.to_string(),
         deployment,
         cipher,
     }
@@ -742,4 +745,129 @@ async fn worker_restart_finishes_stopping_deployment_without_starting_runtime() 
     assert_eq!(stopped.state, DeploymentState::Stopped);
     assert_eq!(runtime.start_calls.load(Ordering::Relaxed), 0);
     assert_eq!(runtime.stop_calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn stopping_a_healthy_compose_deployment_releases_service_and_project() {
+    let context = queued_unresolved_compose_deployment().await;
+    let claimed = context
+        .database
+        .deployments()
+        .claim_next()
+        .await
+        .unwrap()
+        .unwrap();
+    let runtime_ref = format!("ignitify-{}-g{}", claimed.service_id, claimed.generation);
+    context
+        .database
+        .deployments()
+        .record_runtime_ref(claimed.id.as_str(), &runtime_ref)
+        .await
+        .unwrap();
+    context
+        .database
+        .deployments()
+        .transition(
+            claimed.id.as_str(),
+            DeploymentState::Running,
+            Some(&runtime_ref),
+            None,
+        )
+        .await
+        .unwrap();
+    context
+        .database
+        .deployments()
+        .transition(
+            claimed.id.as_str(),
+            DeploymentState::Healthy,
+            Some(&runtime_ref),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let identity = age::x25519::Identity::generate().to_string();
+    let (control, _wake) =
+        ControlHandle::new(context.database.deployments(), identity.expose_secret()).unwrap();
+    let stopping = control
+        .submit_stop(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            claimed.service_id.as_str(),
+        )
+        .await
+        .unwrap();
+    let stopping = match stopping {
+        DeploymentSubmission::Accepted(stopping) => stopping,
+        DeploymentSubmission::Existing(_) => panic!("healthy deployment stop was already active"),
+        DeploymentSubmission::Missing => panic!("healthy deployment service was missing"),
+        DeploymentSubmission::Forbidden => panic!("healthy deployment stop was forbidden"),
+        DeploymentSubmission::ActiveConflict => {
+            panic!("healthy deployment stop reported no active deployment")
+        }
+    };
+    assert_eq!(stopping.state, DeploymentState::Stopping);
+
+    let runtime = RecordingRuntime::new();
+    reconcile_once(
+        &context.database.deployments(),
+        &context.database.domains(),
+        &context.cipher,
+        &runtime,
+        &ReadyIngress,
+        &publisher(),
+    )
+    .await
+    .unwrap();
+
+    let stopped = context
+        .database
+        .deployments()
+        .get(
+            DeploymentActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            claimed.id.as_str(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stopped.state, DeploymentState::Stopped);
+    assert_eq!(runtime.stop_calls.load(Ordering::Relaxed), 1);
+
+    let removed_service = context
+        .database
+        .services()
+        .remove(
+            ServiceActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            claimed.service_id.as_str(),
+            "web",
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        removed_service,
+        ServiceMutationOutcome::Removed(_)
+    ));
+    let removed_project = context
+        .database
+        .projects()
+        .remove(
+            ProjectActor {
+                id: &context.actor_id,
+                is_admin: false,
+            },
+            &context.project_id,
+            "Resilience",
+        )
+        .await
+        .unwrap();
+    assert_eq!(removed_project, ProjectRemoveOutcome::Removed);
 }

--- a/crates/ignitify-db/src/repositories/deployment_lifecycle.rs
+++ b/crates/ignitify-db/src/repositories/deployment_lifecycle.rs
@@ -74,7 +74,13 @@ impl DeploymentsRepository {
             tx.commit().await?;
             return Ok(CancelDeploymentOutcome::Missing);
         };
-        if current.state.is_terminal() || current.state == DeploymentState::Stopping {
+        if matches!(
+            current.state,
+            DeploymentState::Failed
+                | DeploymentState::Stopped
+                | DeploymentState::Superseded
+                | DeploymentState::Stopping
+        ) {
             tx.commit().await?;
             return Ok(CancelDeploymentOutcome::Existing(current));
         }

--- a/crates/ignitify-runtime-compose/src/lib.rs
+++ b/crates/ignitify-runtime-compose/src/lib.rs
@@ -18,7 +18,9 @@ mod render;
 pub use error::Error;
 pub use policy::validate_submission_yaml;
 use policy::{ensure_exposed_service, preflight_yaml, validate_canonical};
-use render::{canonical_volume_names, render_override};
+use render::{
+    GENERATION_LABEL, MANAGED_LABEL, SERVICE_LABEL, canonical_volume_names, render_override,
+};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -227,6 +229,65 @@ impl ComposeRuntime {
             .map_err(Error::Io)
     }
 
+    async fn owned_container_ids(&self, service_id: &str, generation: i64) -> Result<Vec<String>> {
+        let output = self
+            .command([
+                "ps".to_owned(),
+                "--all".to_owned(),
+                "--quiet".to_owned(),
+                "--filter".to_owned(),
+                format!("label={MANAGED_LABEL}=true"),
+                "--filter".to_owned(),
+                format!("label={SERVICE_LABEL}={service_id}"),
+                "--filter".to_owned(),
+                format!("label={GENERATION_LABEL}={generation}"),
+            ])
+            .output()
+            .await
+            .map_err(Error::Io)?;
+        if !output.status.success() {
+            return Err(Error::CommandFailed(
+                "could not list Ignitify-owned Compose containers".to_owned(),
+            ));
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(|id| {
+                if (12..=64).contains(&id.len()) && id.bytes().all(|byte| byte.is_ascii_hexdigit())
+                {
+                    Ok(id.to_owned())
+                } else {
+                    Err(Error::CommandFailed(
+                        "Docker returned an invalid container identifier".to_owned(),
+                    ))
+                }
+            })
+            .collect()
+    }
+
+    async fn remove_owned_containers(&self, service_id: &str, generation: i64) -> Result<()> {
+        let ids = self.owned_container_ids(service_id, generation).await?;
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec![
+            "container".to_owned(),
+            "rm".to_owned(),
+            "--force".to_owned(),
+        ];
+        args.extend(ids);
+        let output = self.command(args).output().await.map_err(Error::Io)?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(Error::CommandFailed(
+                "could not remove Ignitify-owned Compose containers".to_owned(),
+            ))
+        }
+    }
+
     async fn write_override(
         &self,
         stage: &Path,
@@ -394,21 +455,22 @@ impl ImageRuntime for ComposeRuntime {
         let Some(stage) = self.stage_from_runtime_ref(runtime_ref, service_id, generation) else {
             return Ok(false);
         };
-        if fs::metadata(&stage).await.is_err() {
-            return Ok(true);
+        if fs::metadata(&stage).await.is_ok() {
+            // A malformed or missing stage must not prevent cleanup of the exact
+            // Ignitify-owned containers below. Compose output can contain service
+            // configuration, so it is deliberately not surfaced here.
+            let _ = self
+                .run_compose(
+                    &stage,
+                    runtime_ref,
+                    true,
+                    ["down".to_owned(), "--remove-orphans".to_owned()],
+                )
+                .await;
         }
-        let output = self
-            .run_compose(
-                &stage,
-                runtime_ref,
-                true,
-                ["down".to_owned(), "--remove-orphans".to_owned()],
-            )
+        self.remove_owned_containers(service_id, generation)
             .await
             .map_err(control_error)?;
-        if !output.status.success() {
-            return Err(ControlError::Runtime);
-        }
         let _ = fs::remove_dir_all(stage).await;
         Ok(true)
     }

--- a/crates/ignitify-runtime-compose/src/render.rs
+++ b/crates/ignitify-runtime-compose/src/render.rs
@@ -7,8 +7,8 @@ use crate::{Error, Result};
 
 pub(crate) const PROXY_NETWORK: &str = "ignitify-proxy";
 pub(crate) const MANAGED_LABEL: &str = "com.ignitify.managed";
-const SERVICE_LABEL: &str = "com.ignitify.service-id";
-const GENERATION_LABEL: &str = "com.ignitify.generation";
+pub(crate) const SERVICE_LABEL: &str = "com.ignitify.service-id";
+pub(crate) const GENERATION_LABEL: &str = "com.ignitify.generation";
 
 pub(crate) fn render_override(
     deployment: &RuntimeDeployment,

--- a/crates/ignitify-runtime-compose/src/tests.rs
+++ b/crates/ignitify-runtime-compose/src/tests.rs
@@ -44,6 +44,36 @@ fn fake_docker(temp: &tempfile::TempDir) -> std::path::PathBuf {
     executable
 }
 
+#[cfg(unix)]
+fn cleanup_docker(temp: &tempfile::TempDir) -> std::path::PathBuf {
+    let executable = temp.path().join("cleanup-docker");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+printf 'args=' >> "$0.log"
+for argument in "$@"; do printf '<%s>' "$argument" >> "$0.log"; done
+printf '\n' >> "$0.log"
+for argument in "$@"; do
+  if [ "$argument" = down ]; then
+    printf 'down failed\n' >&2
+    exit 1
+  fi
+done
+if [ "$1" = ps ]; then
+  if [ -f "$0.owned-containers" ]; then cat "$0.owned-containers"; fi
+  exit 0
+fi
+if [ "$1" = container ] && [ "$2" = rm ]; then
+  rm -f "$0.owned-containers"
+  exit 0
+fi
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
+    executable
+}
+
 #[test]
 fn compose_command_uses_fixed_argument_order() {
     let args = super::compose_args(
@@ -190,6 +220,85 @@ async fn fake_docker_enforces_fixed_commands_and_cleans_failed_stages() {
     fs::write(docker.with_extension("fail-up"), "").unwrap();
     assert!(runtime.start(&failed_deployment, vec![]).await.is_err());
     assert!(!failed_stage.exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stop_falls_back_to_exact_owned_container_cleanup() {
+    let temp = tempfile::tempdir().unwrap();
+    let docker = cleanup_docker(&temp);
+    let root = temp.path().join("stages");
+    let runtime = super::ComposeRuntime::new(&docker, &root).unwrap();
+    let deployment = deployment();
+    let stage = root.join(deployment.service_id.as_str()).join("1");
+    fs::create_dir_all(&stage).unwrap();
+    let runtime_ref = format!(
+        "ignitify-{}-g{}",
+        deployment.service_id, deployment.generation
+    );
+    let container_id = "a".repeat(64);
+    fs::write(
+        docker.with_extension("owned-containers"),
+        format!("{container_id}\n"),
+    )
+    .unwrap();
+
+    assert!(
+        runtime
+            .stop(
+                &runtime_ref,
+                deployment.service_id.as_str(),
+                deployment.generation,
+            )
+            .await
+            .unwrap()
+    );
+    assert!(!stage.exists());
+    assert!(!docker.with_extension("owned-containers").exists());
+
+    let calls = fs::read_to_string(docker.with_extension("log")).unwrap();
+    assert!(calls.contains("<down><--remove-orphans>"));
+    assert!(calls.contains(&format!(
+        "<ps><--all><--quiet><--filter><label=com.ignitify.managed=true><--filter><label=com.ignitify.service-id={}><--filter><label=com.ignitify.generation=1>",
+        deployment.service_id
+    )));
+    assert!(calls.contains(&format!("<container><rm><--force><{container_id}>")));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn stop_removes_owned_containers_when_compose_stage_is_missing() {
+    let temp = tempfile::tempdir().unwrap();
+    let docker = cleanup_docker(&temp);
+    let root = temp.path().join("stages");
+    let runtime = super::ComposeRuntime::new(&docker, &root).unwrap();
+    let deployment = deployment();
+    let runtime_ref = format!(
+        "ignitify-{}-g{}",
+        deployment.service_id, deployment.generation
+    );
+    let container_id = "b".repeat(64);
+    fs::write(
+        docker.with_extension("owned-containers"),
+        format!("{container_id}\n"),
+    )
+    .unwrap();
+
+    assert!(
+        runtime
+            .stop(
+                &runtime_ref,
+                deployment.service_id.as_str(),
+                deployment.generation,
+            )
+            .await
+            .unwrap()
+    );
+    assert!(!docker.with_extension("owned-containers").exists());
+
+    let calls = fs::read_to_string(docker.with_extension("log")).unwrap();
+    assert!(!calls.contains("<down><--remove-orphans>"));
+    assert!(calls.contains(&format!("<container><rm><--force><{container_id}>")));
 }
 
 #[cfg(unix)]

--- a/docs/id/index.md
+++ b/docs/id/index.md
@@ -7,6 +7,7 @@ Ignitify adalah control plane self-hosted untuk menjalankan aplikasi, layanan Co
 - [Memulai secara lokal](/id/guide/getting-started) untuk menyiapkan backend dan dashboard.
 - [Arsitektur](/id/concepts/architecture) untuk memahami batas setiap crate dan aliran data.
 - [Siklus deployment](/id/concepts/deployment-lifecycle) untuk memahami service, environment, domain, dan worker.
+- [Benchmark footprint baseline](/id/operations/benchmark-baseline) untuk perbandingan idle terkontrol dengan Dokploy.
 - [Referensi API](/id/reference/api) untuk seluruh route HTTP yang terdaftar.
 - [Ignitify Templates](https://github.com/xFlawlessDev/ignitify-templates) untuk daftar template dan kontribusi template publik.
 

--- a/docs/id/operations/benchmark-baseline.md
+++ b/docs/id/operations/benchmark-baseline.md
@@ -1,0 +1,202 @@
+# Benchmark Footprint Baseline
+
+Halaman ini mencatat baseline footprint idle yang dapat diulang untuk Ignitify
+dan Dokploy. Ini adalah bukti dari satu pengujian terkontrol, bukan klaim
+performa universal.
+
+## Cakupan
+
+- Tanggal: 2026-08-15.
+- Host: mesin virtual Ubuntu 24.04 baru yang terpisah, masing-masing satu vCPU.
+- Platform: Ignitify `v0.2.0` dan Dokploy `v0.30.0`.
+- Status: instalasi selesai, endpoint health lokal merespons, tanpa project,
+  aplikasi, atau deployment yang dibuat pengguna.
+- Sampling: 12 sampel pada interval lima detik (total 60 detik), diambil secara
+  paralel setelah kedua control plane sehat.
+- Akses: host key SSH diverifikasi sebelum setiap pengukuran. Record ini tidak
+  mengumpulkan credential maupun data aplikasi.
+
+Kapasitas host awal tidak sama: Ignitify memakai host 1 GiB dan Dokploy memakai
+host 2 GiB. Snapshot instalasi historis tersebut tetap disimpan di bawah, tetapi
+hasil ternormalisasi 1 vCPU / 2 GiB menjadi perbandingan utama.
+
+## Baseline Idle Ternormalisasi
+
+Baseline utama berikut diambil setelah kedua host dinormalisasi menjadi satu
+vCPU dan 1.967 MiB RAM. Kedua platform lebih dahulu dikembalikan ke state baru
+tanpa workload. Dua belas sampel lima detik dikumpulkan paralel setelah control
+plane stabil. CPU host memakai delta dari `/proc/stat`; memori container adalah
+jumlah seluruh container produk yang sedang berjalan.
+
+| Metrik | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Memori host | 1.967 MiB | 1.967 MiB |
+| CPU host rata-rata | 2,17% | 3,57% |
+| Memori tersedia rata-rata | 1.539 MiB | 769 MiB |
+| Container platform berjalan | 3 | 3 |
+| Docker image | 3 | 4 |
+| Penyimpanan Docker image | 350,8 MB | 3,911 GB |
+| Memori container platform rata-rata | 168,3 MiB | 816,4 MiB |
+| Proses control plane khusus rata-rata | 11,5 MiB | N/A (berbasis container) |
+| Total control plane terukur | sekitar 179,8 MiB | sekitar 816,4 MiB |
+| Endpoint health lokal | HTTP 200 | HTTP 200 |
+
+Total container Ignitify terdiri dari Traefik (sekitar 108,9 MiB), Docker read
+proxy (sekitar 10,2 MiB), dan ingress fallback (sekitar 49,2 MiB). Total
+Dokploy terdiri dari aplikasi Dokploy (sekitar 737,2 MiB), PostgreSQL (sekitar
+62,7 MiB), dan Traefik Dokploy (sekitar 17,1 MiB). Nilai ini adalah observasi
+pada pasangan host tersebut, bukan jaminan kapasitas.
+
+## Baseline Instalasi Historis
+
+| Metrik | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Memori host | 961 MiB | 1.967 MiB |
+| CPU host rata-rata | 1,82% | 2,04% |
+| Endpoint health | HTTP 200 | HTTP 307 redirect |
+| Container berjalan | 3 | 2 |
+| Docker image | 3 | 2 |
+| Penyimpanan Docker image | 350,8 MB | 3,677 GB |
+| Proses control plane khusus | 56,2 MiB | N/A (berbasis container) |
+| Memori container platform | 26,3 MiB rata-rata | 995,8 MiB rata-rata cgroup |
+| Memori aplikasi dan database stabil | N/A | 830,1 MiB + 61,3 MiB |
+
+Proses control plane Ignitify yang terukur bersama container platform-nya
+sekitar 82,5 MiB. Sampel warm-up Dokploy yang berulang stabil di sekitar 891,4
+MiB untuk container aplikasi dan PostgreSQL. Rata-rata cgroup dapat mencakup
+efek accounting memori seperti page cache, sehingga pengukuran per-container
+tetap dicatat bersamanya.
+
+Nilai host path Ignitify 98 MiB dan Dokploy 1 MiB sengaja tidak dimasukkan ke
+tabel: kedua produk menyimpan porsi data yang berbeda pada storage yang dikelola
+Docker sehingga path tersebut tidak sebanding.
+
+## Evidence Workload Ternormalisasi
+
+Run workload utama memakai spesifikasi Compose raw yang sama pada setiap host
+ternormalisasi: satu image `nginx:1.27.5-alpine` yang dipin ke
+`sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`.
+Tidak ada port atau domain publik, repository eksternal, secret, maupun data
+aplikasi. Deployment dikirim melalui API masing-masing produk, dan readiness
+mewajibkan request HTTP dari dalam container Nginx yang berjalan ke
+`127.0.0.1:80`.
+
+Setiap platform menerima tiga sampel cold dan tiga sampel warm. Sebelum setiap
+sampel cold, harness hanya menghapus container Nginx benchmark yang
+berlabel/teridentifikasi serta image Nginx cache-nya; sampel warm mempertahankan
+cache image tersebut. Ini mengendalikan status image pull tanpa melewati alur
+deployment produk. Environment production default Ignitify memerlukan approval
+eksplisit segera setelah submission. Alur raw Compose Dokploy tidak memiliki
+aksi approval yang setara.
+
+| Evidence | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Respons API setup | bootstrap 200, project 201, service 201 | sign-up 200, project 200, environment 200, Compose 200 |
+| Approval | diperlukan; seluruh respons approval 202 | tidak digunakan dalam Compose run ini |
+| Sampel cold submit hingga sehat | 10.477 / 10.402 / 37.399 ms | 7.606 / 6.464 / 7.542 ms |
+| Median cold | 10.477 ms | 7.542 ms |
+| Rata-rata cold | 19.426 ms | 7.204 ms |
+| Sampel warm submit hingga sehat | 2.185 / 2.215 / 2.205 ms | 1.286 / 337 / 299 ms |
+| Median warm | 2.205 ms | 337 ms |
+| Rata-rata warm | 2.202 ms | 641 ms |
+| Ignitify approval hingga sehat | cold: 10.447 / 10.352 / 37.369 ms; warm: 2.150 / 2.184 / 2.145 ms | N/A |
+| Pemeriksaan HTTP dalam container | lulus untuk seluruh enam sampel | lulus untuk seluruh enam sampel |
+| Memori container Nginx | 2,355-2,414 MiB | 2,367-2,398 MiB |
+| Storage Docker image dengan workload | 425,2 MB | 3,911 GB |
+| Restart control plane hingga API sehat | 1.137 ms; HTTP workload tetap lulus | 43.231 ms; HTTP workload tetap lulus |
+
+Sampel cold Ignitify 37.399 ms mencapai `healthy` dengan sukses, namun merupakan
+outlier yang material. Nilai tersebut dipertahankan, bukan dibuang. Pengukuran
+Ignitify menghitung dari submission hingga state sehat yang dikonfirmasi worker;
+Dokploy menghitung dari submission hingga container Nginx berjalan dan sehat
+secara internal.
+
+Harness benchmark memperlihatkan dua keterbatasan cleanup yang relevan bagi
+evidence. Endpoint stop Ignitify mengembalikan 202 setelah deployment sehat,
+namun tidak menghapus container workload dalam window observasi 120 detik;
+penghapusan service/project berikutnya mengembalikan 409. Container test yang
+berlabel tepat kemudian dihapus dan state aplikasi test-only di-reset. Enam
+sampel timing Dokploy selesai, tetapi harness gagal saat memformat field memori
+sebelum cleanup API; workload tetap sehat saat control plane restart diukur,
+lalu container Nginx yang tepat dan data aplikasi test-only dihapus. Kedua host
+tidak menyisakan workload benchmark.
+
+Host key SSH diverifikasi sebelum setiap sesi. Output dibatasi pada status HTTP,
+state deployment terminal, waktu, storage agregat, dan memori. Credential,
+token, password yang digenerate, project ID, log, serta nilai konfigurasi hanya
+berada pada file sementara dengan permission terbatas dan tidak dicatat di sini.
+
+Ini adalah pengukuran berulang pada host dengan kapasitas setara, tetapi tetap
+bukan ranking kecepatan platform universal. Pengujian memakai satu image kecil,
+satu pasangan host, eksekusi serial, readiness lokal dari dalam container, serta
+produk dengan semantik approval dan restart berbeda. Latensi ingress publik,
+throughput, dan perilaku gagal di bawah beban belum diukur.
+
+## Evidence Workload Historis
+
+Pengujian satu kali berikut memakai spesifikasi Compose raw yang sama pada kedua
+host. Spesifikasi tersebut hanya berisi image
+`nginx:1.27.5-alpine` yang dipin ke
+`sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`.
+Tidak ada port atau domain publik, repository eksternal, secret, maupun data
+aplikasi. Readiness diperiksa dengan request HTTP dari dalam container yang
+berjalan ke `127.0.0.1:80`.
+
+| Evidence | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Respons API create | bootstrap 200, project 201, service 201, deploy 202 | register 200, project 200, environment 200, Compose 200, deploy 200 |
+| Approval | diperlukan dan disetujui, 202 | tidak digunakan dalam Compose run ini |
+| Submit hingga sehat | 11.509 ms | 8.936 ms |
+| Approval hingga sehat | 11.455 ms | N/A |
+| Pemeriksaan HTTP dalam container | pass | pass |
+| Memori container Nginx | 2,512 MiB | 2,414 MiB |
+| Storage Docker image setelah deployment | 425,2 MB | 3,911 GB |
+| Cleanup API produk | stop/delete awal beradu dengan proses asinkron dan memberi 409; residual terverifikasi dihapus saat reset test | Compose delete 200, project remove 200 |
+
+Setiap koneksi SSH memverifikasi host key ED25519 yang diharapkan sebelum
+menjalankan pengukuran. Output dibatasi pada status HTTP, status deployment
+terminal, waktu, storage Docker agregat, dan memori container. Credential,
+token, password yang digenerate, project ID, log, dan nilai konfigurasi hanya
+berada pada file sementara dengan permission terbatas dan tidak dicatat di sini.
+
+Waktu ini adalah evidence satu deployment image cold pada host yang kapasitasnya
+berbeda. Ini bukan ranking kecepatan platform yang valid: Ignitify juga
+menjalankan workflow approval production, sedangkan kapasitas memori kedua host
+berbeda.
+
+## Interpretasi
+
+Pada host ternormalisasi, Ignitify memakai sekitar 636,6 MiB lebih sedikit
+memori control plane idle terukur dan menyisakan sekitar 770 MiB memori host
+lebih banyak. Storage Docker image instalasinya sekitar 3,56 GB lebih rendah.
+Ini adalah evidence kuat untuk footprint idle yang lebih kecil pada VPS 2 GiB;
+hal ini tidak mengukur kesetaraan fitur, throughput aplikasi berkelanjutan,
+latensi request publik, maupun keandalan di bawah beban.
+
+Dokploy menyelesaikan alur submission hingga sehat yang persis diuji lebih
+cepat pada run ini, khususnya saat cache image warm. Hasil ini harus tetap
+menjadi observasi spesifik workflow, bukan klaim performa seluruh produk:
+Ignitify memiliki transisi approval production, kontrak readiness tidak sama,
+dan hanya satu pasangan host serta image yang dipakai. Restart control plane
+Dokploy yang jauh lebih lama juga merupakan evidence untuk metode restart ini,
+bukan kesimpulan availability umum.
+
+Dokploy dievaluasi pada 2 GiB karena panduan instalasinya menetapkan minimal 2
+GB memori. Percobaan awal pada 1 GiB tidak dipertahankan sebagai hasil benchmark:
+host sudah di-resize sebelum hasil stabil dapat ditetapkan.
+
+## Metode Lanjutan
+
+Benchmark berikutnya harus lebih dahulu menyelesaikan dan memberi regression
+test pada jalur stop/cleanup service sehat yang terlihat di atas. Setelah itu,
+ulangi workload sama pada beberapa pasangan host baru dan catat:
+
+1. Sampel cold dan warm submission hingga sehat dengan median serta sebaran.
+2. Memori control plane dan workload saat idle serta di bawah beban terkontrol.
+3. Latensi HTTP dan error rate melalui hostname ingress nyata yang dialokasikan
+   terpisah.
+4. Waktu pemulihan reboot seluruh host, storage Docker tersisa, dan keberhasilan
+   cleanup melalui API produk.
+
+Jaga pengujian tetap terisolasi dari infrastruktur produksi, gunakan hanya data
+sintetis, dan hapus aplikasi sementara setelah pengujian selesai.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Ignitify is a self-hosted control plane for running applications, Compose servic
 - [Getting started locally](/guide/getting-started) to set up the backend and dashboard.
 - [Architecture](/concepts/architecture) to understand each crate boundary and the data flow.
 - [Deployment lifecycle](/concepts/deployment-lifecycle) to understand services, environments, domains, and workers.
+- [Baseline footprint benchmark](/operations/benchmark-baseline) for a controlled idle comparison with Dokploy.
 - [API reference](/reference/api) for every registered HTTP route.
 - [Ignitify Templates](https://github.com/xFlawlessDev/ignitify-templates) for the public template catalog and contribution workflow.
 

--- a/docs/operations/benchmark-baseline.md
+++ b/docs/operations/benchmark-baseline.md
@@ -1,0 +1,200 @@
+# Baseline Footprint Benchmark
+
+This page records a reproducible idle-footprint baseline for Ignitify and
+Dokploy. It is evidence from one controlled test, not a universal performance
+claim.
+
+## Scope
+
+- Date: 2026-08-15.
+- Hosts: separate, fresh Ubuntu 24.04 virtual machines with one vCPU.
+- Platforms: Ignitify `v0.2.0` and Dokploy `v0.30.0`.
+- State: installation complete, local health endpoint responding, and no
+  user-created projects, applications, or deployments.
+- Sampling: 12 samples at five-second intervals (60 seconds total), taken in
+  parallel after both control planes were healthy.
+- Access: SSH host keys were verified before every measurement. No credentials
+  or application data were collected in this record.
+
+The initial host capacities were not identical: Ignitify used a 1 GiB host and
+Dokploy used a 2 GiB host. That historical installation snapshot is retained
+below, but the normalised 1 vCPU / 2 GiB result is the primary comparison.
+
+## Normalised Idle Baseline
+
+The following primary baseline was collected after both hosts had been
+normalised to one vCPU and 1,967 MiB of RAM. Both platforms were returned to a
+fresh, no-workload state first. Twelve five-second samples were collected in
+parallel after the control planes had settled. Host CPU uses deltas from
+`/proc/stat`; container memory is the sum of all running product containers.
+
+| Metric | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Host memory | 1,967 MiB | 1,967 MiB |
+| Average host CPU | 2.17% | 3.57% |
+| Average available memory | 1,539 MiB | 769 MiB |
+| Running platform containers | 3 | 3 |
+| Docker images | 3 | 4 |
+| Docker image storage | 350.8 MB | 3.911 GB |
+| Average platform-container memory | 168.3 MiB | 816.4 MiB |
+| Average dedicated control-plane process | 11.5 MiB | N/A (containerised) |
+| Measured control-plane total | approximately 179.8 MiB | approximately 816.4 MiB |
+| Local health endpoint | HTTP 200 | HTTP 200 |
+
+The Ignitify container total comprises Traefik (about 108.9 MiB), the Docker
+read proxy (about 10.2 MiB), and the ingress fallback (about 49.2 MiB). The
+Dokploy total comprises the Dokploy application (about 737.2 MiB), PostgreSQL
+(about 62.7 MiB), and Dokploy Traefik (about 17.1 MiB). These are observed
+values on this host pair, not capacity guarantees.
+
+## Historical Installation Baseline
+
+| Metric | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Host memory | 961 MiB | 1,967 MiB |
+| Average host CPU | 1.82% | 2.04% |
+| Health endpoint | HTTP 200 | HTTP 307 redirect |
+| Running containers | 3 | 2 |
+| Docker images | 3 | 2 |
+| Docker image storage | 350.8 MB | 3.677 GB |
+| Dedicated control-plane process | 56.2 MiB | N/A (containerised) |
+| Platform container memory | 26.3 MiB average | 995.8 MiB cgroup average |
+| Stable application and database memory | N/A | 830.1 MiB + 61.3 MiB |
+
+Ignitify's measured control-plane process plus its platform containers was
+approximately 82.5 MiB. Dokploy's repeated warm-up samples were stable at
+approximately 891.4 MiB for its application and PostgreSQL containers. The
+cgroup average can include memory-accounting effects such as page cache, so the
+per-container measurements are retained alongside it.
+
+The 98 MiB Ignitify host-path figure and 1 MiB Dokploy host-path figure are
+intentionally excluded from the table: the two products keep different amounts
+of data in Docker-managed storage, so those paths are not comparable.
+
+## Normalised Workload Evidence
+
+The primary workload run used the same raw Compose specification on each
+normalised host: one `nginx:1.27.5-alpine` image pinned to
+`sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`.
+There were no public ports or domains, external repositories, secrets, or
+application data. Deployment was submitted through each product's API, and
+readiness required an HTTP request from inside the running Nginx container to
+`127.0.0.1:80`.
+
+Each platform received three cold and three warm samples. Before every cold
+sample, the test harness removed only the labelled/identified benchmark Nginx
+container and its cached Nginx image; warm samples retained that image cache.
+This controls image-pull state without bypassing either platform's deployment
+workflow. Ignitify's default production environment required an explicit
+approval immediately after submission. Dokploy's raw-Compose workflow has no
+corresponding approval action.
+
+| Evidence | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Setup API responses | bootstrap 200, project 201, service 201 | sign-up 200, project 200, environment 200, Compose 200 |
+| Approval | required; all approval responses 202 | not part of this Compose run |
+| Cold submit-to-healthy samples | 10,477 / 10,402 / 37,399 ms | 7,606 / 6,464 / 7,542 ms |
+| Cold median | 10,477 ms | 7,542 ms |
+| Cold mean | 19,426 ms | 7,204 ms |
+| Warm submit-to-healthy samples | 2,185 / 2,215 / 2,205 ms | 1,286 / 337 / 299 ms |
+| Warm median | 2,205 ms | 337 ms |
+| Warm mean | 2,202 ms | 641 ms |
+| Ignitify approval-to-healthy | cold: 10,447 / 10,352 / 37,369 ms; warm: 2,150 / 2,184 / 2,145 ms | N/A |
+| In-container HTTP check | pass for all six samples | pass for all six samples |
+| Nginx container memory | 2.355-2.414 MiB | 2.367-2.398 MiB |
+| Docker image storage with workload | 425.2 MB | 3.911 GB |
+| Control-plane restart to healthy API | 1,137 ms; workload HTTP still passed | 43,231 ms; workload HTTP still passed |
+
+The 37,399 ms Ignitify cold sample reached `healthy` successfully but is a
+material outlier. It is retained rather than discarded. The measurement counts
+from submission to worker-confirmed healthy state for Ignitify and from
+submission to a running, internally healthy Nginx container for Dokploy.
+
+The benchmark harness exposed two cleanup limitations that matter to the
+evidence. Ignitify's stop endpoint returned 202 after a healthy deployment but
+did not remove the workload container within the 120-second observation window;
+the subsequent service/project deletion returned 409. The exact labelled test
+container was then removed and the test-only application state reset. Dokploy's
+six timing samples completed, but the harness failed while formatting a memory
+field before API cleanup; its workload remained healthy through the separately
+measured control-plane restart, then the exact Nginx container and test-only
+application data were removed. Neither host retained a benchmark workload.
+
+SSH host keys were verified before every session. Output was limited to HTTP
+status, terminal deployment state, elapsed time, aggregate storage, and memory.
+Credentials, tokens, generated passwords, project IDs, logs, and configuration
+values were kept in mode-restricted temporary files and excluded from this
+record.
+
+These are repeated measurements on equal-capacity hosts, but they are still
+not a universal platform-speed ranking. They use one small image, one host pair,
+serial execution, local in-container readiness, and products with different
+approval and restart semantics. Public ingress latency, throughput, and failure
+behaviour under load were not measured.
+
+## Historical Workload Evidence
+
+The following one-shot run used the same raw Compose specification on both
+hosts. It contains one `nginx:1.27.5-alpine` image pinned to
+`sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`.
+There were no published ports, domains, external repositories, secrets, or
+application data. Readiness was an HTTP request from inside the running
+container to `127.0.0.1:80`.
+
+| Evidence | Ignitify | Dokploy |
+| --- | ---: | ---: |
+| Create API responses | bootstrap 200, project 201, service 201, deploy 202 | register 200, project 200, environment 200, Compose 200, deploy 200 |
+| Approval | required and approved, 202 | not part of this Compose run |
+| Submit to healthy | 11,509 ms | 8,936 ms |
+| Approval to healthy | 11,455 ms | N/A |
+| In-container HTTP check | pass | pass |
+| Nginx container memory | 2.512 MiB | 2.414 MiB |
+| Docker image storage after deployment | 425.2 MB | 3.911 GB |
+| Product API cleanup | initial stop/delete raced and returned 409; verified residual removed during test reset | Compose delete 200, project remove 200 |
+
+Each SSH connection verified the expected ED25519 host key before executing the
+measurement. Output was limited to HTTP status, terminal deployment state,
+elapsed time, Docker aggregate storage, and container memory. Credentials,
+tokens, generated passwords, project IDs, logs, and configuration values were
+kept in mode-restricted temporary files and excluded from this record.
+
+These timings are evidence of one cold image deployment on unequal hosts. They
+are not a valid platform-speed ranking: Ignitify also exercised its production
+approval workflow, and the hosts had different memory capacities.
+
+## Interpretation
+
+On the normalised hosts, Ignitify used approximately 636.6 MiB less measured
+idle control-plane memory and left approximately 770 MiB more host memory
+available. Its installed Docker image storage was approximately 3.56 GB lower.
+This is strong evidence for a smaller idle footprint on a 2 GiB VPS; it does
+not measure feature equivalence, sustained application throughput, public
+request latency, or reliability under load.
+
+Dokploy completed the exact repeated submission-to-healthy workflow faster in
+this run, especially with the image cache warm. That result should remain a
+workflow-specific observation rather than a product-wide performance claim:
+Ignitify includes a production approval transition, the readiness contracts are
+not identical, and only one host pair and image were used. The much slower
+Dokploy control-plane restart is likewise evidence of this restart method, not
+a general availability conclusion.
+
+Dokploy was evaluated at 2 GiB because its installation guidance specifies at
+least 2 GB of memory. An earlier 1 GiB attempt was not retained as a benchmark
+result: the host was resized before a stable result could be established.
+
+## Follow-up Method
+
+A next benchmark should first resolve and regression-test the healthy-service
+stop/cleanup path exposed above. It should then repeat the same workload on
+multiple fresh host pairs and record:
+
+1. Cold and warm submission-to-healthy samples with median and spread.
+2. Control-plane and workload memory during idle and controlled load.
+3. HTTP latency and error rate through a real, separately assigned ingress
+   hostname.
+4. Full-host reboot recovery time, retained Docker storage, and product API
+   cleanup success.
+
+Keep the test isolated from production infrastructure, use synthetic data only,
+and remove any temporary applications when the run is complete.


### PR DESCRIPTION
## Summary
- allow healthy deployments to transition through stop cleanup instead of returning an existing terminal record
- fall back to exact managed/service/generation label cleanup when Compose down or its stage is unavailable
- add control-plane lifecycle coverage through service/project deletion and Compose cleanup regression tests

## Validation
- cargo test --workspace
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- WSL: cargo test -p ignitify-runtime-compose

The benchmark documentation remains in the preceding commit and records the original cleanup observation.