### PR TITLE
docs: add Coolify benchmark comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ requirements and version selection.
 
 - [Capabilities](#capabilities)
 - [At a glance](#at-a-glance)
+- [Footprint benchmark](#footprint-benchmark)
 - [Quick start](#quick-start)
 - [AI assistant](#ai-assistant)
 - [Notification channels](#notification-channels)
@@ -91,6 +92,34 @@ The HTTP API records intent and serves the embedded Vue application. Background
 workers and dedicated adapters carry out external effects, keeping Docker,
 Compose, SSH, Git, DNS, and ingress work out of request handlers. Read the
 [architecture overview](#architecture) for the runtime boundary.
+
+## Footprint Benchmark
+
+The latest controlled idle snapshot used separate Ubuntu 24.04 VPS hosts with
+one vCPU and 1,968 MiB of memory. It collected 12 five-second samples after
+removing the synthetic workload. Ignitify was installed from the
+checksum-verified `v0.2.1` release; Coolify was `v4.3.5` from its official
+installer. The retained Dokploy column is from the validated snapshot before
+that VPS was repurposed for Coolify. [Coolify documents](https://coolify.io/docs/get-started/installation)
+two CPU cores and 2 GiB as its minimum recommended host, so this one-vCPU result
+is a constrained-footprint observation, not a production-sizing recommendation.
+
+| Metric | Ignitify v0.2.1 | Dokploy v0.30.0 (prior snapshot) | Coolify v4.3.5 |
+| --- | ---: | ---: | ---: |
+| Average host CPU | 0.50% | 2.84% | 20.42% |
+| Average host memory used (`MemTotal - MemAvailable`) | 515.0 MiB | 1,404.6 MiB | 895.1 MiB |
+| Average available memory | 1,453.0 MiB | 563.4 MiB | 1,072.9 MiB |
+| Running platform containers | 3 | 3 | 6 |
+| Platform-container memory snapshot | 170.0 MiB | 1,033.8 MiB | 508.4 MiB |
+| Docker image storage after cleanup | 350.8 MB | 3.911 GB | 2.071 GB |
+| Local health endpoint | HTTP 200 | HTTP 200 | HTTP 200 |
+
+This is evidence from one controlled host pair, not a feature-equivalence,
+throughput, public-latency, or reliability claim. The same validation also
+exercised a digest-pinned Nginx Compose workload through Coolify's API: it
+became HTTP-ready in 15.061 seconds, then product cleanup removed the container
+and resource in 7.765 seconds. The Dokploy and Coolify snapshots are separate
+runs on the same normalised host configuration; see the [full benchmark methodology and evidence](docs/operations/benchmark-baseline.md).
 
 ## Quick Start
 

--- a/docs/id/index.md
+++ b/docs/id/index.md
@@ -7,7 +7,7 @@ Ignitify adalah control plane self-hosted untuk menjalankan aplikasi, layanan Co
 - [Memulai secara lokal](/id/guide/getting-started) untuk menyiapkan backend dan dashboard.
 - [Arsitektur](/id/concepts/architecture) untuk memahami batas setiap crate dan aliran data.
 - [Siklus deployment](/id/concepts/deployment-lifecycle) untuk memahami service, environment, domain, dan worker.
-- [Benchmark footprint baseline](/id/operations/benchmark-baseline) untuk perbandingan idle terkontrol dengan Dokploy.
+- [Benchmark footprint baseline](/id/operations/benchmark-baseline) untuk perbandingan idle terkontrol dengan Dokploy dan Coolify.
 - [Referensi API](/id/reference/api) untuk seluruh route HTTP yang terdaftar.
 - [Ignitify Templates](https://github.com/xFlawlessDev/ignitify-templates) untuk daftar template dan kontribusi template publik.
 

--- a/docs/id/operations/benchmark-baseline.md
+++ b/docs/id/operations/benchmark-baseline.md
@@ -1,7 +1,7 @@
 # Benchmark Footprint Baseline
 
-Halaman ini mencatat baseline footprint idle yang dapat diulang untuk Ignitify
-dan Dokploy. Ini adalah bukti dari satu pengujian terkontrol, bukan klaim
+Halaman ini mencatat baseline footprint idle yang dapat diulang untuk Ignitify,
+Dokploy, dan Coolify. Ini adalah bukti dari pengujian terkontrol, bukan klaim
 performa universal.
 
 ## Cakupan
@@ -46,6 +46,128 @@ proxy (sekitar 10,2 MiB), dan ingress fallback (sekitar 49,2 MiB). Total
 Dokploy terdiri dari aplikasi Dokploy (sekitar 737,2 MiB), PostgreSQL (sekitar
 62,7 MiB), dan Traefik Dokploy (sekitar 17,1 MiB). Nilai ini adalah observasi
 pada pasangan host tersebut, bukan jaminan kapasitas.
+
+## Validasi Release v0.2.1
+
+Pada 2026-08-16, bundle release publik `v0.2.1` dipasang melalui installer yang
+memverifikasi checksum pada host Ignitify ternormalisasi yang sama. Host Dokploy
+tetap memakai `v0.30.0`. Ini adalah snapshot validasi release baru, bukan
+pengganti baseline utama di atas. Kedua host Ubuntu 24.04 memiliki satu vCPU dan
+1.968 MiB memori. Dua belas sampel idle lima detik dikumpulkan paralel setelah
+workload test dihapus.
+
+| Metrik | Ignitify v0.2.1 | Dokploy v0.30.0 |
+| --- | ---: | ---: |
+| CPU host rata-rata | 0,41% | 2,84% |
+| Rata-rata memori host terpakai (`MemTotal - MemAvailable`) | 497,6 MiB | 1.404,6 MiB |
+| Memori tersedia rata-rata | 1.470,4 MiB | 563,4 MiB |
+| Container platform berjalan | 3 | 3 |
+| Snapshot memori container platform | 170,0 MiB | 1.033,8 MiB |
+| Snapshot RSS control plane khusus | 53,0 MiB | N/A (berbasis container) |
+| Penyimpanan Docker image setelah cleanup | 350,8 MB | 3,911 GB |
+| Endpoint health lokal | HTTP 200 | HTTP 200 |
+
+Pengukuran Ignitify mencakup satu operator test yang terautentikasi, namun tanpa
+project, service, deployment, maupun workload managed buatan pengguna. Host
+Dokploy juga tidak menyisakan workload benchmark. Memori proses dan container
+harus dibaca sebagai snapshot host pada satu waktu, bukan jaminan kapasitas atau
+perbandingan langsung arsitektur proses.
+
+Memori host terpakai dihitung dari `MemTotal - MemAvailable`, sehingga mencakup
+memori yang dapat direklamasi Linux untuk cache dan bukan total resident memory
+proses. Baris memori tersedia dipertahankan agar perbedaan tersebut eksplisit.
+
+### Bukti Regresi Lifecycle
+
+Benchmark sebelumnya menemukan deployment Compose sehat yang request stop-nya
+mengembalikan `202` tetapi tidak menghapus workload. Release `v0.2.1`
+divalidasi memakai workload Compose Nginx yang dipin sama, tanpa port atau
+domain publik, serta request dari dalam container ke `127.0.0.1:80`.
+Deployment melewati transisi approval production normal.
+
+| Bukti | Hasil |
+| --- | ---: |
+| Pembuatan project dan service Compose | HTTP 201 / HTTP 201 |
+| Submit warm hingga `healthy` yang dikonfirmasi worker | 2.195 ms |
+| Pemeriksaan HTTP dalam container | lulus |
+| Memori container Nginx | 2,363 MiB |
+| Respons stop | HTTP 202 |
+| Stop hingga `stopped` tanpa container workload berlabel | 1.226 ms dan 1.244 ms pada dua run sehat |
+| Container workload berlabel setelah stop | 0 pada kedua run |
+| Penghapusan service setelah stop | HTTP 204 pada kedua run |
+| Penghapusan project setelah stop | HTTP 204 pada kedua run |
+
+Harness benchmark menghapus hanya image Nginx cache yang tepat setelah kedua
+jalur cleanup API produk berhasil. Tidak ada project, service, workload
+deployment, container berlabel, file sementara benchmark, credential, maupun
+token yang disimpan dalam record ini.
+
+## Validasi Coolify v4.3.5
+
+Pada 2026-08-16, host Dokploy dibersihkan sepenuhnya lalu Coolify `v4.3.5`
+dipasang melalui installer resmi Coolify. Perbandingan terbaru memakai host
+Ubuntu 24.04 terpisah yang sama, masing-masing satu vCPU dan 1.968 MiB memori.
+[Dokumentasi instalasi Coolify](https://coolify.io/docs/get-started/installation)
+merekomendasikan minimal dua core CPU dan 2 GiB memori; karena itu run satu-vCPU
+ini adalah observasi footprint terbatas, bukan rekomendasi ukuran produksi.
+
+Setelah workload lifecycle dan image tepatnya dihapus, setiap host memberikan
+12 sampel idle lima detik. CPU host dihitung dari delta CPU-idle `vmstat`;
+memori host terpakai adalah `MemTotal - MemAvailable`; nilai memori container
+adalah satu snapshot `docker stats` ketika platform sudah stabil. Probe health
+platform adalah Ignitify `/health` dan Coolify `/api/health`.
+
+| Metrik | Ignitify v0.2.1 | Dokploy v0.30.0 (snapshot sebelumnya) | Coolify v4.3.5 |
+| --- | ---: | ---: | ---: |
+| Memori host | 1.968 MiB | 1.968 MiB | 1.968 MiB |
+| CPU host rata-rata | 0,50% | 2,84% | 20,42% |
+| Rata-rata memori host terpakai (`MemTotal - MemAvailable`) | 515,0 MiB | 1.404,6 MiB | 895,1 MiB |
+| Memori tersedia rata-rata | 1.453,0 MiB | 563,4 MiB | 1.072,9 MiB |
+| Container platform berjalan | 3 | 3 | 6 |
+| Snapshot memori container platform | 170,0 MiB | 1.033,8 MiB | 508,4 MiB |
+| Penyimpanan Docker image setelah cleanup | 350,8 MB | 3,911 GB | 2,071 GB |
+| Endpoint health lokal | HTTP 200 | HTTP 200 | HTTP 200 |
+
+Kolom Dokploy mempertahankan snapshot validasi release `v0.2.1` yang diambil
+sebelum VPS tersebut dibersihkan dan dipakai ulang untuk Coolify. Bentuk host
+dan kondisi tanpa workload sama, tetapi sampel waktunya tidak sama dengan kolom
+Ignitify / Coolify; gunakan tabel `v0.2.1` sebelumnya untuk hasil Ignitify yang
+berpasangan dengan Dokploy.
+
+Container Coolify yang stabil adalah control plane, PostgreSQL, Redis, layanan
+realtime, proxy Traefik, dan sentinel. Kedua host menyisakan operator yang
+sudah terautentikasi, tetapi tidak ada project benchmark, service, deployment,
+container workload berlabel, token API sementara, maupun akses API aktif.
+Image Nginx yang dibuat juga tidak tersisa setelah cleanup.
+
+### Bukti Lifecycle
+
+Benchmark membuat project dan service Compose raw melalui API Coolify. Input
+Compose hanya memuat digest Nginx yang tepat,
+`nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`;
+tidak ada port atau domain publik. Readiness diperiksa dengan request HTTP dari
+dalam container ke `127.0.0.1:80`. Service Compose raw dipakai karena endpoint
+Docker Image Coolify pada release ini menolak digest pada validasi tag, walau
+request path kemudian dapat mem-parsing referensi image digest.
+
+| Bukti | Hasil |
+| --- | ---: |
+| Pembuatan project dan service | HTTP 201 / HTTP 201 |
+| Request start service | HTTP 200 |
+| Start hingga HTTP dalam container siap | 15.061 ms |
+| Pemeriksaan HTTP dalam container | lulus |
+| Memori container Nginx | 2,406 MiB |
+| Request penghapusan service | HTTP 200 |
+| Penghapusan hingga tanpa container workload dan record service | 7.765 ms |
+| Record service setelah cleanup | HTTP 404 |
+| Container workload setelah cleanup | 0 |
+| Penghapusan project | HTTP 200 |
+
+Token API sementara dibuat hanya untuk run API ini, kemudian segera dihapus,
+dan akses API dinonaktifkan kembali. Host key SSH diverifikasi sebelum setiap
+sesi. Ini adalah observasi workflow spesifik: pengujian ini tidak mengukur
+kesetaraan fitur, throughput aplikasi berkelanjutan, latensi routing eksternal,
+atau pemulihan kegagalan di bawah beban.
 
 ## Baseline Instalasi Historis
 
@@ -112,14 +234,14 @@ Dokploy menghitung dari submission hingga container Nginx berjalan dan sehat
 secara internal.
 
 Harness benchmark memperlihatkan dua keterbatasan cleanup yang relevan bagi
-evidence. Endpoint stop Ignitify mengembalikan 202 setelah deployment sehat,
-namun tidak menghapus container workload dalam window observasi 120 detik;
-penghapusan service/project berikutnya mengembalikan 409. Container test yang
-berlabel tepat kemudian dihapus dan state aplikasi test-only di-reset. Enam
-sampel timing Dokploy selesai, tetapi harness gagal saat memformat field memori
-sebelum cleanup API; workload tetap sehat saat control plane restart diukur,
-lalu container Nginx yang tepat dan data aplikasi test-only dihapus. Kedua host
-tidak menyisakan workload benchmark.
+evidence historis. Endpoint stop Ignitify mengembalikan 202 setelah deployment
+sehat, namun tidak menghapus container workload dalam window observasi 120
+detik; penghapusan service/project berikutnya mengembalikan 409. Jalur
+healthy-stop tersebut sudah diberi regression test dan lulus pada validasi
+release `v0.2.1` di atas. Enam sampel timing Dokploy selesai, tetapi harness
+gagal saat memformat field memori sebelum cleanup API; workload tetap sehat saat
+control plane restart diukur, lalu container Nginx yang tepat dan data aplikasi
+test-only dihapus. Kedua host tidak menyisakan workload benchmark.
 
 Host key SSH diverifikasi sebelum setiap sesi. Output dibatasi pada status HTTP,
 state deployment terminal, waktu, storage agregat, dan memori. Credential,
@@ -187,9 +309,9 @@ host sudah di-resize sebelum hasil stabil dapat ditetapkan.
 
 ## Metode Lanjutan
 
-Benchmark berikutnya harus lebih dahulu menyelesaikan dan memberi regression
-test pada jalur stop/cleanup service sehat yang terlihat di atas. Setelah itu,
-ulangi workload sama pada beberapa pasangan host baru dan catat:
+Validasi `v0.2.1` sudah menyelesaikan dan memberi regression test pada jalur
+stop/cleanup service sehat yang terlihat di atas. Benchmark berikutnya perlu
+mengulangi workload sama pada beberapa pasangan host baru dan mencatat:
 
 1. Sampel cold dan warm submission hingga sehat dengan median serta sebaran.
 2. Memori control plane dan workload saat idle serta di bawah beban terkontrol.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Ignitify is a self-hosted control plane for running applications, Compose servic
 - [Getting started locally](/guide/getting-started) to set up the backend and dashboard.
 - [Architecture](/concepts/architecture) to understand each crate boundary and the data flow.
 - [Deployment lifecycle](/concepts/deployment-lifecycle) to understand services, environments, domains, and workers.
-- [Baseline footprint benchmark](/operations/benchmark-baseline) for a controlled idle comparison with Dokploy.
+- [Baseline footprint benchmark](/operations/benchmark-baseline) for controlled idle comparisons with Dokploy and Coolify.
 - [API reference](/reference/api) for every registered HTTP route.
 - [Ignitify Templates](https://github.com/xFlawlessDev/ignitify-templates) for the public template catalog and contribution workflow.
 

--- a/docs/operations/benchmark-baseline.md
+++ b/docs/operations/benchmark-baseline.md
@@ -1,7 +1,7 @@
 # Baseline Footprint Benchmark
 
-This page records a reproducible idle-footprint baseline for Ignitify and
-Dokploy. It is evidence from one controlled test, not a universal performance
+This page records reproducible idle-footprint baselines for Ignitify, Dokploy,
+and Coolify. It is evidence from controlled tests, not a universal performance
 claim.
 
 ## Scope
@@ -46,6 +46,129 @@ read proxy (about 10.2 MiB), and the ingress fallback (about 49.2 MiB). The
 Dokploy total comprises the Dokploy application (about 737.2 MiB), PostgreSQL
 (about 62.7 MiB), and Dokploy Traefik (about 17.1 MiB). These are observed
 values on this host pair, not capacity guarantees.
+
+## v0.2.1 Release Validation
+
+On 2026-08-16, the public `v0.2.1` release bundle was installed through its
+checksum-verifying installer on the same normalised Ignitify host. The Dokploy
+host remained on `v0.30.0`. This is a fresh release-validation snapshot, not a
+replacement for the primary baseline above. Both Ubuntu 24.04 hosts had one
+vCPU and 1,968 MiB of memory. Twelve five-second idle samples were collected
+in parallel after the test workload had been removed.
+
+| Metric | Ignitify v0.2.1 | Dokploy v0.30.0 |
+| --- | ---: | ---: |
+| Average host CPU | 0.41% | 2.84% |
+| Average host memory used (`MemTotal - MemAvailable`) | 497.6 MiB | 1,404.6 MiB |
+| Average available memory | 1,470.4 MiB | 563.4 MiB |
+| Running platform containers | 3 | 3 |
+| Platform-container memory snapshot | 170.0 MiB | 1,033.8 MiB |
+| Dedicated control-plane RSS snapshot | 53.0 MiB | N/A (containerised) |
+| Docker image storage after cleanup | 350.8 MB | 3.911 GB |
+| Local health endpoint | HTTP 200 | HTTP 200 |
+
+The Ignitify measurement included one authenticated test operator but no
+user-created project, service, deployment, or managed workload. The Dokploy
+host was likewise left without a benchmark workload. Process and container
+memory should be read as a point-in-time host snapshot, rather than a capacity
+guarantee or a direct comparison of process architectures.
+
+Host memory used is derived from `MemTotal - MemAvailable`, so it includes
+memory that Linux can reclaim for cache and is not a process-resident-memory
+total. The available-memory row remains alongside it to make that distinction
+explicit.
+
+### Lifecycle Regression Evidence
+
+The prior benchmark exposed a healthy Compose deployment whose stop request
+returned `202` without removing the workload. Release `v0.2.1` was validated
+with the same pinned Nginx Compose workload, no public port or domain, and an
+in-container request to `127.0.0.1:80`. The deployment required and received
+the normal production approval transition.
+
+| Evidence | Result |
+| --- | ---: |
+| Project and Compose service creation | HTTP 201 / HTTP 201 |
+| Warm submission to worker-confirmed `healthy` | 2,195 ms |
+| In-container HTTP check | pass |
+| Nginx container memory | 2.363 MiB |
+| Stop response | HTTP 202 |
+| Stop to `stopped` with no labelled workload container | 1,226 ms and 1,244 ms across two healthy runs |
+| Labelled workload containers after stop | 0 on both runs |
+| Service deletion after stop | HTTP 204 on both runs |
+| Project deletion after stop | HTTP 204 on both runs |
+
+The benchmark harness removed the exact cached Nginx image only after both
+product API cleanup paths had succeeded. No project, service, deployment
+workload, labelled container, benchmark temporary file, credential, or token
+was retained in this record.
+
+## Coolify v4.3.5 Validation
+
+On 2026-08-16, the Dokploy host was fully cleaned and Coolify `v4.3.5` was
+installed with Coolify's official installer. The updated comparison used the
+same separate Ubuntu 24.04 hosts with one vCPU and 1,968 MiB of memory. The
+[Coolify installation documentation](https://coolify.io/docs/get-started/installation)
+recommends at least two CPU cores and 2 GiB of memory; this one-vCPU run is
+therefore a constrained-footprint observation, not a production-sizing
+recommendation.
+
+After the lifecycle workload and its exact image had been removed, each host
+provided 12 five-second idle samples. Host CPU is calculated from `vmstat`
+CPU-idle deltas; host memory used is `MemTotal - MemAvailable`; the container
+memory value is one settled `docker stats` snapshot. The platform health probes
+were Ignitify `/health` and Coolify `/api/health`.
+
+| Metric | Ignitify v0.2.1 | Dokploy v0.30.0 (prior snapshot) | Coolify v4.3.5 |
+| --- | ---: | ---: | ---: |
+| Host memory | 1,968 MiB | 1,968 MiB | 1,968 MiB |
+| Average host CPU | 0.50% | 2.84% | 20.42% |
+| Average host memory used (`MemTotal - MemAvailable`) | 515.0 MiB | 1,404.6 MiB | 895.1 MiB |
+| Average available memory | 1,453.0 MiB | 563.4 MiB | 1,072.9 MiB |
+| Running platform containers | 3 | 3 | 6 |
+| Platform-container memory snapshot | 170.0 MiB | 1,033.8 MiB | 508.4 MiB |
+| Docker image storage after cleanup | 350.8 MB | 3.911 GB | 2.071 GB |
+| Local health endpoint | HTTP 200 | HTTP 200 | HTTP 200 |
+
+The Dokploy column preserves the `v0.2.1` release-validation snapshot collected
+before that VPS was cleaned and repurposed for Coolify. It is the same host
+shape and no-workload condition, but not the same timed sample as the Ignitify /
+Coolify columns; use the earlier `v0.2.1` table for its paired Ignitify result.
+
+The settled Coolify containers were the control plane, PostgreSQL, Redis,
+realtime service, Traefik proxy, and sentinel. Both hosts were left with an
+authenticated operator but no benchmark project, service, deployment, labelled
+workload container, temporary API token, or enabled API access. The generated
+Nginx image was also absent after cleanup.
+
+### Lifecycle Evidence
+
+The benchmark created a project and a raw Compose service via the Coolify API.
+The Compose input contained only the exact Nginx digest
+`nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10`;
+it exposed no public port or domain. Readiness was an in-container HTTP request
+to `127.0.0.1:80`. A raw Compose service was used because this Coolify release's
+Docker Image endpoint rejects a digest in its tag validation, despite parsing
+digest image references later in the request path.
+
+| Evidence | Result |
+| --- | ---: |
+| Project and service creation | HTTP 201 / HTTP 201 |
+| Service start request | HTTP 200 |
+| Start to in-container HTTP readiness | 15,061 ms |
+| In-container HTTP check | pass |
+| Nginx container memory | 2.406 MiB |
+| Service deletion request | HTTP 200 |
+| Deletion to no workload container and no service record | 7,765 ms |
+| Service record after cleanup | HTTP 404 |
+| Workload containers after cleanup | 0 |
+| Project deletion | HTTP 200 |
+
+The temporary API token was created only for this API run, deleted immediately
+afterward, and API access was disabled again. SSH host keys were verified before
+each session. This is a workflow-specific observation: it does not measure
+feature equivalence, sustained application throughput, external routing
+latency, or failure recovery under load.
 
 ## Historical Installation Baseline
 
@@ -111,14 +234,15 @@ from submission to worker-confirmed healthy state for Ignitify and from
 submission to a running, internally healthy Nginx container for Dokploy.
 
 The benchmark harness exposed two cleanup limitations that matter to the
-evidence. Ignitify's stop endpoint returned 202 after a healthy deployment but
-did not remove the workload container within the 120-second observation window;
-the subsequent service/project deletion returned 409. The exact labelled test
-container was then removed and the test-only application state reset. Dokploy's
-six timing samples completed, but the harness failed while formatting a memory
-field before API cleanup; its workload remained healthy through the separately
-measured control-plane restart, then the exact Nginx container and test-only
-application data were removed. Neither host retained a benchmark workload.
+historical evidence. Ignitify's stop endpoint returned 202 after a healthy
+deployment but did not remove the workload container within the 120-second
+observation window; the subsequent service/project deletion returned 409. That
+healthy-stop path is regression-tested and passes in the `v0.2.1` release
+validation above. Dokploy's six timing samples completed, but the harness
+failed while formatting a memory field before API cleanup; its workload
+remained healthy through the separately measured control-plane restart, then
+the exact Nginx container and test-only application data were removed. Neither
+host retained a benchmark workload.
 
 SSH host keys were verified before every session. Output was limited to HTTP
 status, terminal deployment state, elapsed time, aggregate storage, and memory.
@@ -185,9 +309,9 @@ result: the host was resized before a stable result could be established.
 
 ## Follow-up Method
 
-A next benchmark should first resolve and regression-test the healthy-service
-stop/cleanup path exposed above. It should then repeat the same workload on
-multiple fresh host pairs and record:
+The `v0.2.1` validation resolved and regression-tested the healthy-service
+stop/cleanup path exposed above. A next benchmark should repeat the same
+workload on multiple fresh host pairs and record:
 
 1. Cold and warm submission-to-healthy samples with median and spread.
 2. Control-plane and workload memory during idle and controlled load.


### PR DESCRIPTION
Retains Dokploy evidence alongside the Ignitify and Coolify comparisons. Documents the Coolify idle footprint, lifecycle evidence, and the one-vCPU benchmark limitation. Validation: git diff --check.