### PR TITLE
fix: resolve sha2 0.11 HMAC compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "bech32",
  "chacha20poly1305",
  "cookie-factory",
- "hmac",
+ "hmac 0.12.1",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
@@ -529,6 +529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +701,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +862,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1464,7 +1480,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1474,6 +1490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1837,7 +1862,7 @@ dependencies = [
  "axum",
  "chrono",
  "futures-util",
- "hmac",
+ "hmac 0.13.0",
  "http-body-util",
  "ignitify-auth",
  "ignitify-control-plane",
@@ -1851,7 +1876,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.20",
  "tokio",
@@ -1874,7 +1899,7 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.7",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.20",
  "tokio",
@@ -1885,11 +1910,11 @@ name = "ignitify-backup-s3"
 version = "0.2.2"
 dependencies = [
  "chrono",
- "hmac",
+ "hmac 0.13.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
@@ -2034,7 +2059,7 @@ dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -2067,7 +2092,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tokio",
  "uuid",
  "yaml-rust2",
@@ -2738,7 +2763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4031,7 +4056,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -4070,7 +4095,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bollard = "0.18"
 chrono = { version = "0.4", features = ["clock", "serde"] }
 futures-util = "0.3"
 hickory-resolver = "0.26.1"
-hmac = "0.12"
+hmac = "0.13"
 portable-pty = "0.9"
 jsonwebtoken = "9.3"
 lettre = { version = "0.11", default-features = false, features = ["builder", "smtp-transport", "tokio1-rustls-tls"] }
@@ -26,7 +26,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 resend-rs = { version = "0.29", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 sysinfo = "0.37.2"
 subtle = "2"
 url = "2.5"

--- a/crates/ignitify-api/src/handlers/remote_agent.rs
+++ b/crates/ignitify-api/src/handlers/remote_agent.rs
@@ -249,7 +249,18 @@ fn validate_heartbeat(request: &RemoteServerAgentHeartbeatRequest) -> Result<(),
 }
 
 fn hash_token(token: &str) -> String {
-    format!("{:x}", Sha256::digest(token.as_bytes()))
+    let digest = Sha256::digest(token.as_bytes());
+    hex_encode(digest.as_ref())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }
 
 fn bearer_token(headers: &HeaderMap) -> Option<&str> {

--- a/crates/ignitify-api/src/handlers/webhooks.rs
+++ b/crates/ignitify-api/src/handlers/webhooks.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
 };
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use ignitify_control_plane::DeploymentSubmission;
 use ignitify_db::{DeploymentActor, ProviderKind};
 use serde::Deserialize;
@@ -131,7 +131,7 @@ fn signature_matches(secret: &[u8], body: &[u8], signature: &str) -> WebhookVeri
     let Some(provided) = decode_hex(signature) else {
         return WebhookVerification::Invalid;
     };
-    let Ok(mut mac) = <HmacSha256 as Mac>::new_from_slice(secret) else {
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret) else {
         return WebhookVerification::Invalid;
     };
     mac.update(body);
@@ -247,7 +247,7 @@ mod tests {
         webhook_idempotency_key,
     };
     use axum::http::{HeaderMap, HeaderValue};
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use ignitify_db::ProviderKind;
     use sha2::Sha256;
 

--- a/crates/ignitify-api/src/tests.rs
+++ b/crates/ignitify-api/src/tests.rs
@@ -11,7 +11,7 @@ use axum::{
     http::{Request, StatusCode},
 };
 use futures_util::StreamExt;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use http_body_util::BodyExt;
 use ignitify_auth::AuthConfig;
 use ignitify_control_plane::{
@@ -27,6 +27,16 @@ use sha2::{Digest, Sha256};
 use tower::ServiceExt;
 
 use crate::{DomainPolicy, router, state::AppState};
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
 
 async fn state() -> AppState {
     let database = ignitify_db::Database::connect(&DatabaseConfig {
@@ -843,7 +853,10 @@ async fn verified_github_push_webhook_queues_one_pinned_deployment() {
 
     let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
     mac.update(body);
-    let signature = format!("sha256:{:x}", mac.finalize().into_bytes());
+    let signature = format!(
+        "sha256:{}",
+        hex_encode(mac.finalize().into_bytes().as_ref())
+    );
     let mut valid = Request::builder()
         .method("POST")
         .uri(format!("/api/v1/webhooks/services/{service_id}"))
@@ -865,7 +878,10 @@ async fn verified_github_push_webhook_queues_one_pinned_deployment() {
         .header("x-hub-signature-256", {
             let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
             mac.update(body);
-            format!("sha256:{:x}", mac.finalize().into_bytes())
+            format!(
+                "sha256:{}",
+                hex_encode(mac.finalize().into_bytes().as_ref())
+            )
         })
         .header("x-github-delivery", "delivery-1")
         .body(Body::from(body.as_slice().to_vec()))
@@ -930,7 +946,8 @@ async fn remote_agent_heartbeat_authenticates_and_persists_metrics() {
         .await
         .unwrap();
     let token = "agent-test-token";
-    let hash = format!("{:x}", Sha256::digest(token.as_bytes()));
+    let digest = Sha256::digest(token.as_bytes());
+    let hash = hex_encode(digest.as_ref());
     state
         .database
         .remote_server_agents()

--- a/crates/ignitify-auth/src/lib.rs
+++ b/crates/ignitify-auth/src/lib.rs
@@ -450,7 +450,18 @@ fn generate_token() -> String {
 fn hash_token(value: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(value.as_bytes());
-    format!("{:x}", hasher.finalize())
+    let digest = hasher.finalize();
+    hex_encode(digest.as_ref())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }
 
 fn authenticated_user_with_session(

--- a/crates/ignitify-backup-s3/src/upload.rs
+++ b/crates/ignitify-backup-s3/src/upload.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use reqwest::{
     Client, StatusCode,
     header::{CONTENT_LENGTH, CONTENT_TYPE},

--- a/crates/ignitify-runtime-compose/src/render.rs
+++ b/crates/ignitify-runtime-compose/src/render.rs
@@ -72,13 +72,24 @@ pub(crate) fn canonical_volume_names(
         .map(|name| {
             let mut digest = Sha256::new();
             digest.update(name.as_bytes());
-            let digest = format!("{:x}", digest.finalize());
+            let digest = digest.finalize();
+            let digest = hex_encode(digest.as_ref());
             (
                 name.clone(),
                 format!("ignitify-{}-{}", deployment.service_id, &digest[..24]),
             )
         })
         .collect()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }
 
 fn yaml_quote(value: &str) -> String {

--- a/crates/ignitify-runtime-remote/src/lib.rs
+++ b/crates/ignitify-runtime-remote/src/lib.rs
@@ -261,13 +261,24 @@ impl SshRuntime {
             .map(|name| {
                 let mut digest = Sha256::new();
                 digest.update(name.as_bytes());
-                let digest = format!("{:x}", digest.finalize());
+                let digest = digest.finalize();
+                let digest = Self::hex_encode(digest.as_ref());
                 (
                     name.to_owned(),
                     format!("ignitify-{}-{}", deployment.service_id, &digest[..24]),
                 )
             })
             .collect())
+    }
+
+    fn hex_encode(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut output = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            output.push(HEX[(byte >> 4) as usize] as char);
+            output.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        output
     }
 
     fn compose_script(


### PR DESCRIPTION
## Summary
- upgrade workspace sha2 to 0.11 and direct hmac to 0.13
- migrate HMAC initialization to KeyInit
- preserve hex token, signature, and volume-name output with explicit encoding

## Validation
- cargo fmt --all -- --check
- cargo check --workspace --locked --offline
- cargo test --workspace --locked --offline
- cargo clippy --workspace --all-targets --locked --offline -- -D warnings

Supersedes #31, whose sha2-only update cannot compile with hmac 0.12 / digest 0.10.