### PR TITLE
chore(release): prepare v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-api"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "age",
  "argon2",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-auth"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "argon2",
  "base64 0.23.1",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-backup-s3"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-control-plane"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "age",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "age",
  "axum",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-db"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "ignitify-domain",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-dns"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "hickory-resolver",
  "ignitify-control-plane",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-domain"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-ingress-traefik"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-db",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-monitoring"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "ignitify-db",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-notifications"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "ignitify-control-plane",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-compose"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-docker"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-remote"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64 0.23.1",
  "ignitify-control-plane",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-source-git"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-terminal"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "portable-pty",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitify-frontend",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary\n- bump workspace and frontend version metadata to 0.2.4\n- publish the installer fix in the v0.2.4 release bundle\n\n## Validation\n- version metadata synchronized with scripts/version.sh --set 0.2.4\n- release workflow triggered by tag v0.2.4