### PR TITLE
Fix duplicate Docker apt source warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-api"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "age",
  "argon2",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-auth"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "argon2",
  "base64 0.23.1",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-backup-s3"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-control-plane"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "age",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "age",
  "axum",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-db"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "ignitify-domain",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-dns"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "hickory-resolver",
  "ignitify-control-plane",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-domain"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-ingress-traefik"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-db",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-monitoring"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "ignitify-db",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-notifications"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "ignitify-control-plane",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-compose"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-docker"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-remote"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "ignitify-control-plane",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-source-git"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-terminal"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "portable-pty",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitify-frontend",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -164,13 +164,6 @@ install_apt_prerequisites() {
   require_command apt-get
   require_command dpkg
   installed_debian_conflicts
-  apt-get update
-  apt-get install -y ca-certificates curl git gnupg openssh-client
-  install -m 0755 -d /etc/apt/keyrings
-  curl -fsSL "https://download.docker.com/linux/$distribution/gpg" -o /etc/apt/keyrings/docker.asc
-  chmod a+r /etc/apt/keyrings/docker.asc
-  codename="${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}"
-  [[ -n "$codename" ]] || die "could not determine the $distribution release codename"
 
   # Older Docker setup instructions use docker.list. Remove only that known
   # official Docker source so it does not duplicate the canonical deb822 file.
@@ -181,6 +174,14 @@ install_apt_prerequisites() {
     && ! grep -E -v -q "$legacy_source_allowed_pattern" "$legacy_source"; then
     rm -f -- "$legacy_source"
   fi
+
+  apt-get update
+  apt-get install -y ca-certificates curl git gnupg openssh-client
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL "https://download.docker.com/linux/$distribution/gpg" -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  codename="${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}"
+  [[ -n "$codename" ]] || die "could not determine the $distribution release codename"
 
   cat > /etc/apt/sources.list.d/docker.sources <<EOF
 Types: deb


### PR DESCRIPTION
## Summary
- remove a legacy official Docker list source before the first apt update
- keep the held-package update fix in the release installer
- prepare v0.2.5 so latest-install downloads the corrected bundle

## Validation
- release tag v0.2.5 pushed
- GitHub release workflow will run the Linux build and package checks