### PR TITLE
chore(release): prepare v0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-api"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "age",
  "argon2",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-auth"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "argon2",
  "base64 0.23.1",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-backup-s3"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-control-plane"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "age",
  "chrono",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "age",
  "axum",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-db"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "ignitify-domain",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-dns"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "hickory-resolver",
  "ignitify-control-plane",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-domain"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-ingress-traefik"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-db",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-monitoring"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "ignitify-db",
@@ -2037,7 +2037,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-notifications"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "ignitify-control-plane",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-compose"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-docker"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-remote"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64 0.23.1",
  "ignitify-control-plane",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-source-git"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-terminal"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "portable-pty",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitify-frontend",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- synchronize Rust workspace and frontend version metadata to 0.2.7
- prepare the source tree for the v0.2.7 release tag

## Validation
- cargo metadata --no-deps --locked --format-version 1
- git diff --check