### PR TITLE
fix: restore managed Traefik fallback routing

### DIFF
--- a/crates/ignitify-ingress-traefik/src/lib.rs
+++ b/crates/ignitify-ingress-traefik/src/lib.rs
@@ -4,7 +4,10 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     process::Stdio,
-    sync::{Arc, RwLock},
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use ignitify_control_plane::{
@@ -37,6 +40,7 @@ pub struct TraefikIngress {
     operator: OperatorConfig,
     routing_policy: Arc<RwLock<RoutingPolicy>>,
     operator_email: Arc<RwLock<Option<String>>>,
+    operator_started: Arc<AtomicBool>,
     server_settings: Option<ServerSettingsSource>,
 }
 
@@ -85,6 +89,7 @@ impl TraefikIngress {
             operator: OperatorConfig::from_environment(),
             routing_policy: Arc::new(RwLock::new(RoutingPolicy::default())),
             operator_email: Arc::new(RwLock::new(None)),
+            operator_started: Arc::new(AtomicBool::new(false)),
             server_settings: None,
         }
     }
@@ -99,6 +104,7 @@ impl TraefikIngress {
             operator: OperatorConfig::from_environment(),
             routing_policy: Arc::new(RwLock::new(RoutingPolicy::default())),
             operator_email: Arc::new(RwLock::new(None)),
+            operator_started: Arc::new(AtomicBool::new(false)),
             server_settings: Some(ServerSettingsSource {
                 database,
                 cipher,
@@ -123,7 +129,10 @@ impl TraefikIngress {
 
     pub async fn ensure_started(&self) -> bool {
         let desired_email = self.desired_acme_email().await;
-        if self.ready().await && self.operator_email_matches(&desired_email) {
+        if self.operator_started.load(Ordering::Acquire)
+            && self.ready().await
+            && self.operator_email_matches(&desired_email)
+        {
             return true;
         }
         if !self.operator.auto_start {
@@ -134,6 +143,7 @@ impl TraefikIngress {
             return false;
         }
         self.set_operator_email(desired_email);
+        self.operator_started.store(true, Ordering::Release);
         self.ready().await
     }
 
@@ -145,6 +155,9 @@ impl TraefikIngress {
         write_fallback_page(&source.fallback_page_path, &settings)
             .map_err(|_| ControlError::Runtime)?;
         self.reconcile_operator_email(&settings.acme_email).await?;
+        if !self.ensure_started().await {
+            return Err(ControlError::Runtime);
+        }
         let policy = RoutingPolicy::from_settings(&settings);
         let mut current = self
             .routing_policy
@@ -190,6 +203,7 @@ impl TraefikIngress {
                 .start(desired.as_deref())
                 .await
                 .map_err(|_| ControlError::Runtime)?;
+            self.operator_started.store(true, Ordering::Release);
         }
         self.set_operator_email(desired);
         Ok(())

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -252,6 +252,8 @@ install_ingress_assets() {
   local dynamic_dir="$DATA_DIR/traefik/dynamic"
   local fallback_dir="$DATA_DIR/traefik/fallback"
   local fallback_page="$fallback_dir/404.html"
+  local compose_env="$target/.env"
+  local temporary_env
   local required
 
   for required in \
@@ -277,6 +279,24 @@ install_ingress_assets() {
   install -o root -g root -m 0644 "$INGRESS_SOURCE/fallback/ignitify-mark.svg" "$target/fallback/ignitify-mark.svg"
   install -o root -g root -m 0644 "$INGRESS_SOURCE/socket-proxy/Dockerfile" "$target/socket-proxy/Dockerfile"
   install -o root -g root -m 0755 "$INGRESS_SOURCE/socket-proxy/entrypoint.sh" "$target/socket-proxy/entrypoint.sh"
+
+  # Compose reads .env beside compose.yaml when operators start the stack
+  # manually. Keep its bind mounts aligned with the service environment while
+  # preserving optional operator settings such as the ACME email.
+  if [[ -e "$compose_env" && ! -f "$compose_env" ]]; then
+    die "Traefik Compose environment is not a regular file: $compose_env"
+  fi
+  temporary_env="$(mktemp)"
+  trap 'rm -f "$temporary_env"' RETURN
+  if [[ -f "$compose_env" ]]; then
+    awk '!/^[[:space:]]*(IGNITIFY_TRAEFIK_DYNAMIC_DIR|IGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE)=/' \
+      "$compose_env" > "$temporary_env"
+  fi
+  printf '\nIGNITIFY_TRAEFIK_DYNAMIC_DIR=%s\nIGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=%s\n' \
+    "$dynamic_dir" "$fallback_page" >> "$temporary_env"
+  install -o root -g root -m 0644 "$temporary_env" "$compose_env"
+  rm -f "$temporary_env"
+  trap - RETURN
 
   # Reapply ownership and modes on every install. `install -d` only applies
   # attributes while creating a directory, so an upgrade must repair paths


### PR DESCRIPTION
### Summary
- keep manually started Traefik Compose mounts aligned with Ignitify runtime paths
- reconcile the operator stack during the first backend reconciliation
- restore the branded fallback route after installs or manual stack drift

### Validation\n- cargo test -p ignitify-ingress-traefik
- cargo check -p ignitify-ingress-traefik -p ignitify-control-plane
- cargo fmt --all -- --check

Fixes the default Traefik 404 page not found response when the stack was created without the runtime environment paths.