### PR TITLE
fix: release Traefik dynamic config permission fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-api"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "age",
  "argon2",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-auth"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "argon2",
  "base64 0.23.1",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-backup-s3"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-control-plane"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "age",
  "chrono",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-core"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "age",
  "axum",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-db"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "ignitify-domain",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-dns"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "hickory-resolver",
  "ignitify-control-plane",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-domain"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-ingress-traefik"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-db",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-monitoring"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "ignitify-db",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-notifications"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "ignitify-control-plane",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-compose"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-docker"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-remote"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "base64 0.23.1",
  "ignitify-control-plane",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-source-git"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-terminal"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "portable-pty",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.95"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitify-frontend",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/infra/traefik/compose.yaml
+++ b/infra/traefik/compose.yaml
@@ -33,6 +33,11 @@ services:
 
   traefik:
     image: traefik:v3.6.21@sha256:850b1b3484519b12353d9679ec3246e63a42df2cc640bf8e6fa50267d589f5a0
+    # Traefik needs root to traverse the service-owned 0700 dynamic directory
+    # and to initialize the ACME file in entrypoint.sh. The container remains
+    # read-only, drops all capabilities except binding ports, and disallows
+    # privilege escalation.
+    user: "${IGNITIFY_TRAEFIK_USER:-0:0}"
     labels:
       com.ignitify.ingress: traefik
     command:

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -289,10 +289,10 @@ install_ingress_assets() {
   temporary_env="$(mktemp)"
   trap 'rm -f "$temporary_env"' RETURN
   if [[ -f "$compose_env" ]]; then
-    awk '!/^[[:space:]]*(IGNITIFY_TRAEFIK_DYNAMIC_DIR|IGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE)=/' \
+    awk '!/^[[:space:]]*(IGNITIFY_TRAEFIK_DYNAMIC_DIR|IGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE|IGNITIFY_TRAEFIK_USER)=/' \
       "$compose_env" > "$temporary_env"
   fi
-  printf '\nIGNITIFY_TRAEFIK_DYNAMIC_DIR=%s\nIGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=%s\n' \
+  printf '\nIGNITIFY_TRAEFIK_DYNAMIC_DIR=%s\nIGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=%s\nIGNITIFY_TRAEFIK_USER=0:0\n' \
     "$dynamic_dir" "$fallback_page" >> "$temporary_env"
   install -o root -g root -m 0644 "$temporary_env" "$compose_env"
   rm -f "$temporary_env"
@@ -347,6 +347,7 @@ IGNITIFY_DATABASE_URL=sqlite:$DATA_DIR/ignitify.db
 IGNITIFY_COMPOSE_ROOT=$DATA_DIR/compose
 IGNITIFY_SOURCE_BUILD_ROOT=$DATA_DIR/builds
 IGNITIFY_TRAEFIK_DYNAMIC_DIR=$DATA_DIR/traefik/dynamic
+IGNITIFY_TRAEFIK_USER=0:0
 IGNITIFY_AUTO_START_INGRESS=$ingress_auto_start
 IGNITIFY_ALLOW_LOCAL_BUILDS=$local_builds
 # Configure a TLS reverse proxy, trusted HTTPS origins, ACME email, and domains before remote access.
@@ -362,14 +363,38 @@ EOF
 ensure_ingress_runtime_config() {
   [[ "$INSTALL_INGRESS_ASSETS" -eq 1 ]] || return 0
 
-  if awk '/^[[:space:]]*IGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=/{found=1} END {exit !found}' "$CONFIG_FILE"; then
-    return 0
+  local changed=0
+  if ! awk '/^[[:space:]]*IGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=/{found=1} END {exit !found}' "$CONFIG_FILE"; then
+    printf '\nIGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=%s\n' "$DATA_DIR/traefik/fallback/404.html" >> "$CONFIG_FILE"
+    changed=1
   fi
 
-  printf '\nIGNITIFY_TRAEFIK_FALLBACK_PAGE_FILE=%s\n' "$DATA_DIR/traefik/fallback/404.html" >> "$CONFIG_FILE"
-  chown root:root "$CONFIG_FILE"
-  chmod 0600 "$CONFIG_FILE"
-  info "configured runtime Traefik fallback page"
+  if awk '/^[[:space:]]*IGNITIFY_TRAEFIK_USER=/{found=1} END {exit !found}' "$CONFIG_FILE"; then
+    local temporary_config
+    temporary_config="$(mktemp)"
+    trap 'rm -f "$temporary_config"' RETURN
+    awk '
+      /^[[:space:]]*IGNITIFY_TRAEFIK_USER=/ {
+        if (!replaced) print "IGNITIFY_TRAEFIK_USER=0:0"
+        replaced = 1
+        next
+      }
+      { print }
+    ' "$CONFIG_FILE" > "$temporary_config"
+    install -o root -g root -m 0600 "$temporary_config" "$CONFIG_FILE"
+    rm -f "$temporary_config"
+    trap - RETURN
+    changed=1
+  else
+    printf '\nIGNITIFY_TRAEFIK_USER=0:0\n' >> "$CONFIG_FILE"
+    changed=1
+  fi
+
+  if [[ "$changed" -eq 1 ]]; then
+    chown root:root "$CONFIG_FILE"
+    chmod 0600 "$CONFIG_FILE"
+    info "configured runtime Traefik paths"
+  fi
 }
 
 write_launcher() {


### PR DESCRIPTION
## Summary\n- run the pinned Traefik container as root by default so it can traverse the service-owned 0700 dynamic directory\n- persist IGNITIFY_TRAEFIK_USER=0:0 in generated and upgraded installer environments\n- bump release metadata to 0.2.10\n\n## Validation\n- cargo test -p ignitify-ingress-traefik\n- cargo check --workspace\n- cargo fmt --all -- --check\n- bash syntax check for scripts/install-release.sh\n\nResolves Traefik failing to load /etc/traefik/dynamic with permission denied, which removed edirect-to-https@file and caused HTTP requests to fall through to the default 404.