### PR TITLE
fix: allow Traefik to read managed dynamic config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-api"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "age",
  "argon2",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-auth"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "argon2",
  "base64 0.23.1",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-backup-s3"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-control-plane"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "age",
  "chrono",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-core"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "age",
  "axum",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-db"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "ignitify-domain",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-dns"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "hickory-resolver",
  "ignitify-control-plane",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-domain"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-ingress-traefik"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-db",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-monitoring"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "ignitify-db",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-notifications"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "ignitify-control-plane",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-compose"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "ignitify-control-plane",
  "ignitify-domain",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-docker"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "bollard",
  "futures-util",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-runtime-remote"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "base64 0.23.1",
  "ignitify-control-plane",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-source-git"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "ignitify-terminal"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "portable-pty",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.95"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignitify-frontend",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/infra/traefik/compose.yaml
+++ b/infra/traefik/compose.yaml
@@ -33,10 +33,10 @@ services:
 
   traefik:
     image: traefik:v3.6.21@sha256:850b1b3484519b12353d9679ec3246e63a42df2cc640bf8e6fa50267d589f5a0
-    # Traefik needs root to traverse the service-owned 0700 dynamic directory
-    # and to initialize the ACME file in entrypoint.sh. The container remains
-    # read-only, drops all capabilities except binding ports, and disallows
-    # privilege escalation.
+    # Traefik needs root plus DAC_READ_SEARCH to traverse the service-owned
+    # 0700 dynamic directory and read managed certificate files. The container
+    # remains read-only, drops every other capability, and disallows privilege
+    # escalation.
     user: "${IGNITIFY_TRAEFIK_USER:-0:0}"
     labels:
       com.ignitify.ingress: traefik
@@ -67,6 +67,7 @@ services:
     cap_drop:
       - ALL
     cap_add:
+      - DAC_READ_SEARCH
       - NET_BIND_SERVICE
     networks:
       - internal


### PR DESCRIPTION
## Summary\n- grant Traefik the minimal DAC_READ_SEARCH capability required to traverse service-owned 0700 dynamic config and certificate directories\n- retain root entrypoint, read-only filesystem, capability drop, and no-new-privileges hardening\n- bump release metadata to v0.2.11\n\n## Validation\n- cargo test -p ignitify-ingress-traefik\n- cargo check --workspace\n- cargo fmt --all -- --check\n- installer shell syntax check